### PR TITLE
Add Supabase MCP integration to engineering agents

### DIFF
--- a/agents/lead_engineer.py
+++ b/agents/lead_engineer.py
@@ -2,7 +2,7 @@
 Lead Engineer Agent Configuration
 
 The Lead Engineer can read PRDs, save architecture documents, code reviews,
-and interact with GitHub repositories via MCP.
+and interact with GitHub and Supabase via MCP.
 """
 
 import os
@@ -24,6 +24,10 @@ github_mcp = MCPTools(
     env={"GITHUB_TOKEN": os.environ.get("GITHUB_TOKEN", "")}
 )
 
+supabase_mcp = MCPTools(
+    command=f"npx -y @supabase/mcp-server-supabase@latest --access-token={os.environ.get('SUPABASE_ACCESS_TOKEN', '')}"
+)
+
 lead_engineer_agent = Agent(
     name="Lead Engineer Agent",
     role="Designs technical architecture, creates technical specifications, provides code review guidance, and offers technical leadership on implementation approaches.",
@@ -40,5 +44,6 @@ lead_engineer_agent = Agent(
             enable_list_files=True,
         ),
         github_mcp,
+        supabase_mcp,
     ]
 )

--- a/agents/software_engineer.py
+++ b/agents/software_engineer.py
@@ -2,7 +2,7 @@
 Software Engineer Agent Configuration
 
 The Software Engineer can read technical documents, save implementation code files,
-and interact with GitHub repositories via MCP.
+and interact with GitHub and Supabase via MCP.
 """
 
 import os
@@ -24,6 +24,10 @@ github_mcp = MCPTools(
     env={"GITHUB_TOKEN": os.environ.get("GITHUB_TOKEN", "")}
 )
 
+supabase_mcp = MCPTools(
+    command=f"npx -y @supabase/mcp-server-supabase@latest --access-token={os.environ.get('SUPABASE_ACCESS_TOKEN', '')}"
+)
+
 software_engineer_agent = Agent(
     name="Software Engineer Agent",
     role="Implements code, fixes bugs, writes tests, and creates code documentation. Handles version control and follows coding best practices.",
@@ -40,5 +44,6 @@ software_engineer_agent = Agent(
             enable_list_files=True,
         ),
         github_mcp,
+        supabase_mcp,
     ]
 )


### PR DESCRIPTION
## Summary
- Enable Lead Engineer and Software Engineer agents to interact with Supabase
- Add Supabase MCP server for database schemas, edge functions, and project management
- Authenticate via SUPABASE_ACCESS_TOKEN environment variable

## Test plan
- [ ] Set SUPABASE_ACCESS_TOKEN environment variable with valid Supabase access token
- [ ] Start server and verify agents can access Supabase
- [ ] Test database schema and project operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)