### PR TITLE
feat: add Vercel MCP integration to engineering agents

### DIFF
--- a/agents/lead_engineer.py
+++ b/agents/lead_engineer.py
@@ -2,7 +2,7 @@
 Lead Engineer Agent Configuration
 
 The Lead Engineer can read PRDs, save architecture documents, code reviews,
-and interact with GitHub and Supabase via MCP.
+and interact with GitHub, Supabase, and Vercel via MCP.
 """
 
 import os
@@ -28,6 +28,10 @@ supabase_mcp = MCPTools(
     command=f"npx -y @supabase/mcp-server-supabase@latest --access-token={os.environ.get('SUPABASE_ACCESS_TOKEN', '')}"
 )
 
+vercel_mcp = MCPTools(
+    command=f"npx -y mcp-remote https://mcp.vercel.com --header \"Authorization: Bearer {os.environ.get('VERCEL_TOKEN', '')}\""
+)
+
 lead_engineer_agent = Agent(
     name="Lead Engineer Agent",
     role="Designs technical architecture, creates technical specifications, provides code review guidance, and offers technical leadership on implementation approaches.",
@@ -45,5 +49,6 @@ lead_engineer_agent = Agent(
         ),
         github_mcp,
         supabase_mcp,
+        vercel_mcp,
     ]
 )

--- a/agents/software_engineer.py
+++ b/agents/software_engineer.py
@@ -2,7 +2,7 @@
 Software Engineer Agent Configuration
 
 The Software Engineer can read technical documents, save implementation code files,
-and interact with GitHub and Supabase via MCP.
+and interact with GitHub, Supabase, and Vercel via MCP.
 """
 
 import os
@@ -28,6 +28,10 @@ supabase_mcp = MCPTools(
     command=f"npx -y @supabase/mcp-server-supabase@latest --access-token={os.environ.get('SUPABASE_ACCESS_TOKEN', '')}"
 )
 
+vercel_mcp = MCPTools(
+    command=f"npx -y mcp-remote https://mcp.vercel.com --header \"Authorization: Bearer {os.environ.get('VERCEL_TOKEN', '')}\""
+)
+
 software_engineer_agent = Agent(
     name="Software Engineer Agent",
     role="Implements code, fixes bugs, writes tests, and creates code documentation. Handles version control and follows coding best practices.",
@@ -45,5 +49,6 @@ software_engineer_agent = Agent(
         ),
         github_mcp,
         supabase_mcp,
+        vercel_mcp,
     ]
 )


### PR DESCRIPTION
## Summary
- Adds Vercel MCP integration to Lead Engineer and Software Engineer agents
- Enables agents to manage Vercel projects, deployments, and analyze logs
- Uses `VERCEL_TOKEN` environment variable for authentication

## Test plan
- [ ] Set `VERCEL_TOKEN` environment variable
- [ ] Run agents and verify Vercel MCP tools are available
- [ ] Test Vercel project management capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)