### PR TITLE
fix: check repo existence before creation to avoid 422 errors

### DIFF
--- a/instructions/software_engineer_instructions.py
+++ b/instructions/software_engineer_instructions.py
@@ -63,13 +63,17 @@ Languages & Frameworks:
 7. GITHUB REPOSITORY & FILE STORAGE:
    When instructed to save code to GitHub:
 
-   **IMPORTANT - Repository Setup:**
-   - FIRST, check if the repository exists using `get_repository` tool
-   - If you get a "Not Found" error, CREATE the repository first using `create_repository` tool:
-     - name: the repository name
-     - description: brief description of the project
-     - private: false (unless specified otherwise)
-   - Only AFTER the repository exists, proceed to create files
+   **IMPORTANT - Repository Setup (ALWAYS follow this order):**
+   1. FIRST, call `get_repository` to check if the repository exists
+      - owner: the GitHub owner/organization
+      - repo: the repository name
+   2. If `get_repository` returns "Not Found" error → call `create_repository`:
+      - name: the repository name
+      - description: brief description of the project
+      - private: false (unless specified otherwise)
+   3. If `get_repository` returns successfully → the repo exists, DO NOT call `create_repository`
+   4. NEVER call `create_repository` if the repo already exists - this causes 422 errors
+   5. Only AFTER confirming the repository exists, proceed to create/update files
 
    **File Operations:**
    - Use the GitHub MCP `create_or_update_file` tool to save files

--- a/workflows/implementation_cycle_workflow.py
+++ b/workflows/implementation_cycle_workflow.py
@@ -222,15 +222,21 @@ def run_development(step_input: StepInput) -> StepOutput:
 
 **CRITICAL INSTRUCTIONS - READ CAREFULLY:**
 
-**STEP 1: CREATE THE REPOSITORY (call ONCE)**
+**STEP 1: CHECK IF REPOSITORY EXISTS (call ONCE)**
+Call `get_repository` with these parameters:
+- owner: "{_state.github_owner}"
+- repo: "{_state.github_repo}"
+
+If you get a successful response (repository exists), skip to STEP 3.
+If you get a "Not Found" error, proceed to STEP 2.
+
+**STEP 2: CREATE THE REPOSITORY (ONLY if Step 1 returned "Not Found")**
 Call `create_repository` with these parameters:
 - name: "{_state.github_repo}"
 - description: "Implementation for {workflow_input.product_name}"
 - private: false
 
-Wait for the result. If repo already exists (error 422), that's fine - proceed.
-
-**STEP 2: SAVE YOUR CODE FILE (call ONCE)**
+**STEP 3: SAVE YOUR CODE FILE (call ONCE)**
 Call `create_or_update_file` with these parameters:
 - owner: "{_state.github_owner}"
 - repo: "{_state.github_repo}"
@@ -240,8 +246,9 @@ Call `create_or_update_file` with these parameters:
 - branch: "main"
 
 **IMPORTANT RULES:**
-- Call each tool EXACTLY ONCE - do NOT retry if you get a result back
-- Do NOT call `get_file_contents` or `get_repository` in this step
+- Call `get_repository` first to check if the repo exists
+- Only call `create_repository` if the repo does NOT exist (Not Found error)
+- NEVER call `create_repository` if the repo already exists - this causes errors
 - After `create_or_update_file` returns, STOP calling tools and write your response
 - If a tool call fails with an error, report the error - do NOT retry
 


### PR DESCRIPTION
When using the GitHub MCP to create a repository, if the repo already exists, it returns a 422 error which causes the workflow to fail. This fix updates the workflow to:
1. First call get_repository to check if the repo exists
2. Only call create_repository if the repo doesn't exist
3. Proceed directly to file creation if repo already exists

This prevents the "name already exists on this account" error that was causing the software engineer agent to fail on iteration 1.

https://claude.ai/code/session_01D8EHddupR41trjeFrRWEhg