### PR TITLE
feat: add Railway support for Google Docs OAuth

### DIFF
--- a/tests/google_docs/oauth_server.py
+++ b/tests/google_docs/oauth_server.py
@@ -2,20 +2,16 @@
 """
 Google Docs OAuth2 Server
 
-FastAPI server that handles the full OAuth2 flow:
-  1. /authorize        -> Redirects to Google login
-  2. /google-callback  -> Exchanges code for access + refresh tokens
-  3. /test             -> Creates, reads, and updates a Google Doc
+Standalone service for getting Google OAuth tokens.
+After authorization, displays the full JSON token for copying to Railway env vars.
 
-Tokens are persisted to tests/google_docs/token.json for reuse.
-
-Run:
-    cd <project-root>
-    source venv/bin/activate
-    pip install -r requirements.txt
+Run locally:
     python tests/google_docs/oauth_server.py
 
-    Then open http://localhost:8000
+Deploy to Railway:
+    - Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET env vars
+    - Set OAUTH_REDIRECT_URI to your Railway URL + /google-callback
+    - Run command: python tests/google_docs/oauth_server.py
 """
 
 import os
@@ -24,25 +20,27 @@ import secrets
 import requests as http_requests
 import uvicorn
 from pathlib import Path
-from datetime import datetime
 from urllib.parse import urlencode
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
-from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 
 # ---------------------------------------------------------------------------
-# Configuration - Set these in your .env file or environment variables
+# Configuration
 # ---------------------------------------------------------------------------
 CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID")
 CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET")
 
 if not CLIENT_ID or not CLIENT_SECRET:
     raise ValueError(
-        "Missing Google OAuth credentials. Please set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET environment variables."
+        "Missing Google OAuth credentials.\n"
+        "Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET environment variables."
     )
-REDIRECT_URI = "http://localhost:8000/google-callback"
+
+# For Railway: set OAUTH_REDIRECT_URI to your deployed URL
+# Example: https://your-app.up.railway.app/google-callback
+PORT = int(os.environ.get("PORT", 8000))
+BASE_URL = os.environ.get("OAUTH_BASE_URL", f"http://localhost:{PORT}")
+REDIRECT_URI = f"{BASE_URL}/google-callback"
 
 SCOPES = [
     "https://www.googleapis.com/auth/documents",
@@ -52,66 +50,12 @@ SCOPES = [
 AUTH_URI = "https://accounts.google.com/o/oauth2/auth"
 TOKEN_URI = "https://oauth2.googleapis.com/token"
 
-# Token is stored alongside this file so it's easy to find and .gitignore
-TOKEN_DIR = Path(__file__).resolve().parent
-TOKEN_FILE = TOKEN_DIR / "token.json"
-
 # ---------------------------------------------------------------------------
 # FastAPI app
 # ---------------------------------------------------------------------------
-app = FastAPI(title="Google Docs OAuth2 Server")
+app = FastAPI(title="Google OAuth Token Generator")
 oauth_state: dict = {}
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def save_token(token_data: dict) -> None:
-    """Persist token to disk."""
-    with open(TOKEN_FILE, "w") as f:
-        json.dump(token_data, f, indent=2)
-    print(f"   Token saved -> {TOKEN_FILE}")
-
-
-def load_credentials() -> Credentials:
-    """Load credentials from token.json and refresh if needed."""
-    if not TOKEN_FILE.exists():
-        raise FileNotFoundError(
-            f"Token file not found: {TOKEN_FILE}\n"
-            "Visit http://localhost:8000/authorize to create one."
-        )
-
-    with open(TOKEN_FILE) as f:
-        data = json.load(f)
-
-    creds = Credentials(
-        token=data["token"],
-        refresh_token=data.get("refresh_token"),
-        token_uri=TOKEN_URI,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
-        scopes=SCOPES,
-    )
-
-    # Auto-refresh if expired
-    if creds.expired and creds.refresh_token:
-        from google.auth.transport.requests import Request as GoogleRequest
-
-        print("   Token expired - refreshing...")
-        creds.refresh(GoogleRequest())
-        save_token({
-            "token": creds.token,
-            "refresh_token": creds.refresh_token,
-            "token_uri": TOKEN_URI,
-            "client_id": CLIENT_ID,
-            "client_secret": CLIENT_SECRET,
-            "scopes": SCOPES,
-        })
-        print("   Token refreshed")
-
-    return creds
-
+latest_token: dict = {}  # Store latest token in memory for display
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -119,41 +63,69 @@ def load_credentials() -> Credentials:
 
 @app.get("/", response_class=HTMLResponse)
 async def home():
-    token_exists = TOKEN_FILE.exists()
-    status_html = (
-        '<div class="status success">Token found - <a href="/test">Run Test</a></div>'
-        if token_exists
-        else '<div class="status warn">No token yet - authorize first</div>'
-    )
+    has_token = bool(latest_token)
+
+    token_section = ""
+    if has_token:
+        token_json = json.dumps(latest_token, separators=(',', ':'))
+        token_section = f'''
+        <div class="token-box">
+            <h2>Your Token (copy this for GOOGLE_DOCS_TOKEN env var):</h2>
+            <textarea id="token" readonly onclick="this.select()">{token_json}</textarea>
+            <button onclick="copyToken()">Copy to Clipboard</button>
+            <p class="success">Token generated successfully!</p>
+        </div>
+        <script>
+            function copyToken() {{
+                const textarea = document.getElementById('token');
+                textarea.select();
+                document.execCommand('copy');
+                alert('Token copied to clipboard!');
+            }}
+            console.log('GOOGLE_DOCS_TOKEN:', {json.dumps(token_json)});
+        </script>
+        '''
 
     return f"""<!DOCTYPE html>
-<html><head><title>Google Docs OAuth2</title>
+<html><head><title>Google OAuth Token Generator</title>
 <style>
-  body {{ font-family: system-ui, sans-serif; max-width: 700px; margin: 50px auto; padding: 20px; background: #f5f5f5; }}
-  .card {{ background: #fff; padding: 32px; border-radius: 10px; box-shadow: 0 2px 8px rgba(0,0,0,.08); }}
-  h1 {{ color: #1a73e8; margin-top: 0; }}
-  .btn {{ display: inline-block; padding: 10px 22px; border-radius: 5px; text-decoration: none; color: #fff; font-weight: 500; margin: 6px 4px; }}
-  .btn.primary {{ background: #1a73e8; }}
-  .btn.green {{ background: #34a853; }}
-  .status {{ padding: 12px; border-radius: 5px; margin: 16px 0; }}
-  .status.success {{ background: #e6f4ea; color: #137333; border-left: 4px solid #34a853; }}
-  .status.warn {{ background: #fef7e0; color: #8a6d3b; border-left: 4px solid #f9ab00; }}
-  pre {{ background: #f8f9fa; padding: 12px; border-radius: 5px; font-size: 13px; overflow-x: auto; }}
+  body {{ font-family: system-ui, sans-serif; max-width: 900px; margin: 50px auto; padding: 20px; background: #1a1a2e; color: #eee; }}
+  .card {{ background: #16213e; padding: 32px; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,.3); }}
+  h1 {{ color: #4ecca3; margin-top: 0; }}
+  h2 {{ color: #4ecca3; font-size: 1.1em; margin-bottom: 10px; }}
+  .btn {{ display: inline-block; padding: 12px 28px; border-radius: 6px; text-decoration: none; color: #fff; font-weight: 600; margin: 8px 4px; border: none; cursor: pointer; font-size: 1em; }}
+  .btn.primary {{ background: #4ecca3; color: #1a1a2e; }}
+  .btn.primary:hover {{ background: #3db892; }}
+  .info {{ background: #0f3460; padding: 16px; border-radius: 8px; margin: 20px 0; }}
+  .info code {{ background: #1a1a2e; padding: 2px 8px; border-radius: 4px; }}
+  .token-box {{ background: #0f3460; padding: 20px; border-radius: 8px; margin: 20px 0; }}
+  .token-box textarea {{ width: 100%; height: 120px; background: #1a1a2e; color: #4ecca3; border: 1px solid #4ecca3; border-radius: 6px; padding: 12px; font-family: monospace; font-size: 12px; resize: vertical; }}
+  .token-box button {{ background: #4ecca3; color: #1a1a2e; border: none; padding: 10px 20px; border-radius: 6px; cursor: pointer; font-weight: 600; margin-top: 10px; }}
+  .token-box button:hover {{ background: #3db892; }}
+  .success {{ color: #4ecca3; font-weight: 600; }}
+  .warn {{ color: #f39c12; }}
 </style></head>
 <body><div class="card">
-  <h1>Google Docs OAuth2 Test</h1>
-  {status_html}
-  <p>Redirect URI: <code>{REDIRECT_URI}</code></p>
+  <h1>Google OAuth Token Generator</h1>
+
+  <div class="info">
+    <p><strong>Redirect URI:</strong> <code>{REDIRECT_URI}</code></p>
+    <p class="warn">Make sure this URI is added to your Google Cloud Console OAuth credentials!</p>
+  </div>
+
   <a href="/authorize" class="btn primary">Authorize with Google</a>
-  <a href="/test" class="btn green">Run Test</a>
-  <a href="/status" class="btn primary">Token Status</a>
-  <h3>Endpoints</h3>
-  <pre>GET /              Home (this page)
-GET /authorize     Start OAuth2 flow
-GET /google-callback   Callback (automatic)
-GET /test          Create, read, update a Google Doc
-GET /status        Token status
-GET /token         Token info (JSON)</pre>
+
+  {token_section}
+
+  <div class="info" style="margin-top: 30px;">
+    <h3>How to use:</h3>
+    <ol>
+      <li>Click "Authorize with Google"</li>
+      <li>Sign in and grant permissions</li>
+      <li>Copy the JSON token displayed</li>
+      <li>Paste it as <code>GOOGLE_DOCS_TOKEN</code> in Railway</li>
+    </ol>
+  </div>
 </div></body></html>"""
 
 
@@ -179,16 +151,35 @@ async def authorize():
 
 @app.get("/google-callback")
 async def google_callback(code: str = None, state: str = None, error: str = None):
-    """Exchange authorization code for tokens and persist them."""
+    """Exchange authorization code for tokens and display them."""
+    global latest_token
 
     if error:
-        return HTMLResponse(f"<h2>Authorization error: {error}</h2><a href='/'>Home</a>")
+        return HTMLResponse(f"""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;text-align:center;">
+  <h1>Authorization Error</h1>
+  <p>{error}</p>
+  <a href="/" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
 
     if state != oauth_state.get("current"):
-        return HTMLResponse("<h2>Invalid state (CSRF check failed)</h2><a href='/'>Home</a>")
+        return HTMLResponse("""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;text-align:center;">
+  <h1>Invalid State</h1>
+  <p>CSRF check failed. Please try again.</p>
+  <a href="/" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
 
     if not code:
-        return HTMLResponse("<h2>No authorization code received</h2><a href='/'>Home</a>")
+        return HTMLResponse("""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;text-align:center;">
+  <h1>No Code</h1>
+  <p>No authorization code received.</p>
+  <a href="/" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
 
     print(f"\n-> Callback received, exchanging code...")
 
@@ -202,153 +193,102 @@ async def google_callback(code: str = None, state: str = None, error: str = None
     })
 
     if resp.status_code != 200:
-        return HTMLResponse(
-            f"<h2>Token exchange failed ({resp.status_code})</h2>"
-            f"<pre>{resp.text}</pre><a href='/'>Home</a>"
-        )
+        return HTMLResponse(f"""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;">
+  <h1>Token Exchange Failed</h1>
+  <pre style="background:#0f3460;padding:20px;border-radius:8px;color:#eee;">{resp.text}</pre>
+  <a href="/" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
 
     tokens = resp.json()
-    print(f"   Access token:  {tokens['access_token'][:24]}...")
-    print(f"   Refresh token: {str(tokens.get('refresh_token', ''))[:24]}...")
 
-    save_token({
+    # Build the token object for GOOGLE_DOCS_TOKEN env var
+    latest_token = {
         "token": tokens["access_token"],
         "refresh_token": tokens.get("refresh_token"),
         "token_uri": TOKEN_URI,
         "client_id": CLIENT_ID,
         "client_secret": CLIENT_SECRET,
         "scopes": SCOPES,
-    })
+    }
 
-    return RedirectResponse("/test")
+    token_json = json.dumps(latest_token, separators=(',', ':'))
+    token_pretty = json.dumps(latest_token, indent=2)
 
+    print(f"\n{'='*60}")
+    print("TOKEN GENERATED - Copy this for GOOGLE_DOCS_TOKEN:")
+    print(f"{'='*60}")
+    print(token_json)
+    print(f"{'='*60}\n")
 
-@app.get("/status")
-async def status():
-    if not TOKEN_FILE.exists():
-        return HTMLResponse(
-            "<h2>No token found</h2>"
-            "<a href='/authorize'>Authorize now</a>"
-        )
-    with open(TOKEN_FILE) as f:
-        data = json.load(f)
-    return HTMLResponse(
-        f"<h2>Token Status</h2>"
-        f"<p>Access token: <code>{data['token'][:30]}...</code></p>"
-        f"<p>Refresh token: <code>{'present' if data.get('refresh_token') else 'missing'}</code></p>"
-        f"<p>File: <code>{TOKEN_FILE}</code></p>"
-        f"<a href='/test'>Run Test</a> | <a href='/'>Home</a>"
-    )
+    return f"""<!DOCTYPE html>
+<html><head><title>Token Generated!</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; max-width: 900px; margin: 50px auto; padding: 20px; background: #1a1a2e; color: #eee; }}
+  .card {{ background: #16213e; padding: 32px; border-radius: 12px; }}
+  h1 {{ color: #4ecca3; }}
+  .token-box {{ background: #0f3460; padding: 20px; border-radius: 8px; margin: 20px 0; }}
+  .token-box label {{ color: #4ecca3; font-weight: 600; display: block; margin-bottom: 8px; }}
+  .token-box textarea {{ width: 100%; background: #1a1a2e; color: #4ecca3; border: 2px solid #4ecca3; border-radius: 6px; padding: 12px; font-family: monospace; font-size: 12px; resize: vertical; }}
+  .minified {{ height: 80px; }}
+  .pretty {{ height: 200px; }}
+  button {{ background: #4ecca3; color: #1a1a2e; border: none; padding: 12px 24px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 1em; margin: 5px; }}
+  button:hover {{ background: #3db892; }}
+  .success {{ color: #4ecca3; font-size: 1.2em; }}
+  .info {{ background: #0f3460; padding: 16px; border-radius: 8px; margin: 20px 0; }}
+</style>
+<script>
+  function copyMinified() {{
+    document.getElementById('minified').select();
+    document.execCommand('copy');
+    alert('Minified token copied!');
+  }}
+  function copyPretty() {{
+    document.getElementById('pretty').select();
+    document.execCommand('copy');
+    alert('Pretty token copied!');
+  }}
+  // Also log to console
+  console.log('GOOGLE_DOCS_TOKEN (minified):', {json.dumps(token_json)});
+</script>
+</head>
+<body><div class="card">
+  <h1>Token Generated Successfully!</h1>
+  <p class="success">Your Google OAuth token is ready.</p>
+
+  <div class="token-box">
+    <label>Minified (for Railway env var):</label>
+    <textarea id="minified" class="minified" readonly onclick="this.select()">{token_json}</textarea>
+    <button onclick="copyMinified()">Copy Minified</button>
+  </div>
+
+  <div class="token-box">
+    <label>Pretty (for reading):</label>
+    <textarea id="pretty" class="pretty" readonly onclick="this.select()">{token_pretty}</textarea>
+    <button onclick="copyPretty()">Copy Pretty</button>
+  </div>
+
+  <div class="info">
+    <h3>Next steps:</h3>
+    <ol>
+      <li>Copy the <strong>minified</strong> token above</li>
+      <li>Go to Railway Dashboard → Your Service → Variables</li>
+      <li>Add: <code>GOOGLE_DOCS_TOKEN</code> = [paste the token]</li>
+      <li>Redeploy your service</li>
+    </ol>
+  </div>
+
+  <a href="/" style="color:#4ecca3;">← Back to Home</a>
+</div></body></html>"""
 
 
 @app.get("/token")
-async def token_json():
-    if not TOKEN_FILE.exists():
-        return JSONResponse({"error": "No token"}, status_code=404)
-    with open(TOKEN_FILE) as f:
-        data = json.load(f)
-    return JSONResponse({
-        "token": data["token"][:30] + "...",
-        "has_refresh_token": data.get("refresh_token") is not None,
-        "file": str(TOKEN_FILE),
-    })
-
-
-@app.get("/test", response_class=HTMLResponse)
-async def run_test():
-    """Create -> Read -> Update -> Read a Google Doc and show results."""
-    out: list[str] = []
-
-    def log(msg: str):
-        out.append(msg)
-        print(msg)
-
-    try:
-        log("Loading credentials...")
-        creds = load_credentials()
-        service = build("docs", "v1", credentials=creds)
-
-        # -- CREATE --------------------------------------------------------
-        title = f"OAuth2 Test - {datetime.now().strftime('%Y%m%d_%H%M%S')}"
-        log(f"\n[1] Creating document: {title}")
-        doc = service.documents().create(body={"title": title}).execute()
-        doc_id = doc["documentId"]
-        doc_url = f"https://docs.google.com/document/d/{doc_id}/edit"
-        log(f"    ID:  {doc_id}")
-        log(f"    URL: {doc_url}")
-
-        # -- READ (empty) --------------------------------------------------
-        log("\n[2] Reading empty document")
-        doc = service.documents().get(documentId=doc_id).execute()
-        log(f"    Title: {doc['title']}  (content is empty)")
-
-        # -- UPDATE ---------------------------------------------------------
-        log("\n[3] Inserting content")
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        text = (
-            f"Google Docs API Test\n\n"
-            f"Created: {ts}\n\n"
-            f"This document was created through the FastAPI OAuth2 callback flow.\n\n"
-            f"Features tested:\n"
-            f"  - OAuth2 web flow with callback\n"
-            f"  - Token exchange and storage\n"
-            f"  - Document creation\n"
-            f"  - Content insertion\n"
-            f"  - Document reading\n\n"
-            f"Status: All tests passed!\n"
-        )
-        service.documents().batchUpdate(
-            documentId=doc_id,
-            body={"requests": [{"insertText": {"location": {"index": 1}, "text": text}}]},
-        ).execute()
-        log(f"    Inserted {len(text)} characters")
-
-        # -- READ (final) ---------------------------------------------------
-        log("\n[4] Reading final document")
-        final = service.documents().get(documentId=doc_id).execute()
-        content = ""
-        for el in final.get("body", {}).get("content", []):
-            if "paragraph" in el:
-                for run in el["paragraph"].get("elements", []):
-                    if "textRun" in run:
-                        content += run["textRun"].get("content", "")
-
-        log("-" * 60)
-        log(content.strip())
-        log("-" * 60)
-
-        log("\nAll tests passed!")
-
-        # -- HTML output ----------------------------------------------------
-        escaped = "\n".join(out).replace("&", "&amp;").replace("<", "&lt;")
-        return f"""<!DOCTYPE html>
-<html><head><title>Test Results</title>
-<style>
-  body {{ font-family: 'Monaco', monospace; background: #1e1e1e; color: #d4d4d4; padding: 20px; }}
-  .box {{ max-width: 900px; margin: 0 auto; background: #252526; padding: 28px; border-radius: 10px; }}
-  h1 {{ color: #4ec9b0; font-family: system-ui; }}
-  pre {{ white-space: pre-wrap; line-height: 1.6; }}
-  .btn {{ display: inline-block; margin-top: 16px; padding: 10px 20px; background: #0e639c; color: #fff; text-decoration: none; border-radius: 5px; }}
-</style></head>
-<body><div class="box">
-  <h1>Test Passed</h1>
-  <pre>{escaped}</pre>
-  <a class="btn" href="{doc_url}" target="_blank">Open Document</a>
-  <a class="btn" href="/">Home</a>
-</div></body></html>"""
-
-    except Exception as exc:
-        import traceback
-
-        out.append(f"\nERROR: {exc}")
-        out.append(traceback.format_exc())
-        escaped = "\n".join(out).replace("&", "&amp;").replace("<", "&lt;")
-        return f"""<!DOCTYPE html>
-<html><head><title>Test Failed</title></head>
-<body style="font-family:monospace;background:#1e1e1e;color:#f48771;padding:20px;">
-  <h1>Test Failed</h1><pre>{escaped}</pre>
-  <a href="/" style="color:#4ec9b0;">Home</a>
-</body></html>"""
+async def get_token():
+    """Return the latest token as JSON (for API access)."""
+    if not latest_token:
+        return JSONResponse({"error": "No token generated yet. Visit /authorize first."}, status_code=404)
+    return JSONResponse(latest_token)
 
 
 # ---------------------------------------------------------------------------
@@ -357,17 +297,16 @@ async def run_test():
 
 if __name__ == "__main__":
     print("=" * 70)
-    print("  Google Docs OAuth2 Server")
+    print("  Google OAuth Token Generator")
     print("=" * 70)
     print(f"  Client ID:    {CLIENT_ID[:30]}...")
+    print(f"  Base URL:     {BASE_URL}")
     print(f"  Redirect URI: {REDIRECT_URI}")
-    print(f"  Token file:   {TOKEN_FILE}")
-    print(f"  Server:       http://localhost:8000")
+    print(f"  Port:         {PORT}")
     print("=" * 70)
     print()
-    print("  1. Open  http://localhost:8000")
+    print("  1. Open the URL above")
     print("  2. Click 'Authorize with Google'")
-    print("  3. Log in and grant permissions")
-    print("  4. Test runs automatically")
+    print("  3. Copy the token JSON for Railway")
     print()
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/tools/google_docs_tools.py
+++ b/tools/google_docs_tools.py
@@ -1,10 +1,17 @@
 """
 Google Docs Tools
 
-Creates real Google Docs via OAuth2 token stored at tests/google_docs/token.json.
-Token is obtained by running: python tests/google_docs/oauth_server.py
+Creates real Google Docs via OAuth2 token.
+
+Token sources (checked in order):
+1. GOOGLE_DOCS_TOKEN environment variable (JSON string) - for production/Railway
+2. tests/google_docs/token.json file - for local development
+
+To get a token locally:
+  python tests/google_docs/oauth_server.py
 """
 
+import os
 import json
 from pathlib import Path
 
@@ -14,7 +21,7 @@ from google.auth.transport.requests import Request as GoogleRequest
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-# Token path (relative to project root)
+# Token path (relative to project root) - fallback for local development
 TOKEN_FILE = Path(__file__).resolve().parent.parent / "tests" / "google_docs" / "token.json"
 
 TOKEN_URI = "https://oauth2.googleapis.com/token"
@@ -25,19 +32,34 @@ SCOPES = [
 
 
 def _load_credentials() -> Credentials:
-    """Load OAuth2 credentials from token.json and auto-refresh if expired."""
-    if not TOKEN_FILE.exists():
+    """
+    Load OAuth2 credentials from environment variable or token.json file.
+
+    Priority:
+    1. GOOGLE_DOCS_TOKEN env var (JSON string) - for Railway/production
+    2. tests/google_docs/token.json file - for local development
+    """
+    # Try environment variable first (for Railway/production)
+    token_json = os.environ.get("GOOGLE_DOCS_TOKEN")
+
+    if token_json:
+        try:
+            data = json.loads(token_json)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"GOOGLE_DOCS_TOKEN is not valid JSON: {e}")
+    elif TOKEN_FILE.exists():
+        with open(TOKEN_FILE) as f:
+            data = json.load(f)
+    else:
         raise FileNotFoundError(
-            "Google Docs OAuth2 token not found.\n"
-            f"Expected at: {TOKEN_FILE}\n\n"
-            "To create one:\n"
+            "Google Docs OAuth2 token not found.\n\n"
+            "For production (Railway):\n"
+            "  Set GOOGLE_DOCS_TOKEN environment variable with the JSON content\n\n"
+            "For local development:\n"
             "  1. python tests/google_docs/oauth_server.py\n"
             "  2. Open http://localhost:8000 and authorize\n"
-            "  3. Token will be saved automatically"
+            "  3. Token will be saved to tests/google_docs/token.json"
         )
-
-    with open(TOKEN_FILE) as f:
-        data = json.load(f)
 
     creds = Credentials(
         token=data["token"],
@@ -48,17 +70,20 @@ def _load_credentials() -> Credentials:
         scopes=SCOPES,
     )
 
+    # Auto-refresh if expired
     if creds.expired and creds.refresh_token:
         creds.refresh(GoogleRequest())
-        with open(TOKEN_FILE, "w") as f:
-            json.dump({
-                "token": creds.token,
-                "refresh_token": creds.refresh_token,
-                "token_uri": TOKEN_URI,
-                "client_id": data.get("client_id", ""),
-                "client_secret": data.get("client_secret", ""),
-                "scopes": SCOPES,
-            }, f, indent=2)
+        # Only update file if we're using file-based token (not env var)
+        if not token_json and TOKEN_FILE.exists():
+            with open(TOKEN_FILE, "w") as f:
+                json.dump({
+                    "token": creds.token,
+                    "refresh_token": creds.refresh_token,
+                    "token_uri": TOKEN_URI,
+                    "client_id": data.get("client_id", ""),
+                    "client_secret": data.get("client_secret", ""),
+                    "scopes": SCOPES,
+                }, f, indent=2)
 
     return creds
 
@@ -71,7 +96,10 @@ def _get_docs_service():
 class GoogleDocsTools(Toolkit):
     """
     Tools for creating Google Docs documents via the real Docs API.
-    Requires OAuth2 token at tests/google_docs/token.json.
+
+    Token sources (checked in order):
+    1. GOOGLE_DOCS_TOKEN env var (JSON string) - for Railway/production
+    2. tests/google_docs/token.json file - for local development
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
- GoogleDocsTools now reads from GOOGLE_DOCS_TOKEN env var first
- OAuth server displays full JSON token with copy buttons
- OAuth server configurable via OAUTH_BASE_URL for Railway deployment
- Token also logged to browser console for easy copying