### PR TITLE
fix: Railway deployment - add nixpacks.toml for Python detection

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn agno_agent:app --host 0.0.0.0 --port ${PORT:-8000}
+web: python -m uvicorn agno_agent:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,8 @@
+[phases.setup]
+nixPkgs = ["python311", "nodejs_20"]
+
+[phases.install]
+cmds = ["pip install -r requirements.txt"]
+
+[start]
+cmd = "python -m uvicorn agno_agent:app --host 0.0.0.0 --port ${PORT:-8000}"

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "uvicorn agno_agent:app --host 0.0.0.0 --port ${PORT:-8000}",
+    "startCommand": "python -m uvicorn agno_agent:app --host 0.0.0.0 --port ${PORT:-8000}",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
- Added nixpacks.toml to ensure Python and Node.js are installed
- Changed uvicorn to python -m uvicorn for better PATH compatibility
- This fixes "uvicorn: command not found" error on Railway