### PR TITLE
fix: Railway - add Python provider and pip package to nixpacks

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,8 +1,12 @@
+# Force Python provider
+providers = ["python"]
+
 [phases.setup]
-nixPkgs = ["python311", "nodejs_20"]
+nixPkgs = ["python311", "python311Packages.pip", "nodejs_20"]
 
 [phases.install]
-cmds = ["pip install -r requirements.txt"]
+dependsOn = ["setup"]
+cmds = ["python -m pip install -r requirements.txt"]
 
 [start]
 cmd = "python -m uvicorn agno_agent:app --host 0.0.0.0 --port ${PORT:-8000}"


### PR DESCRIPTION
- Added providers = ["python"] to force Python detection
- Added python311Packages.pip to ensure pip is available
- Changed pip to python -m pip for better compatibility