### PR TITLE
feat: add built-in Google OAuth token generator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,12 +26,16 @@ SUPABASE_ACCESS_TOKEN=your-supabase-access-token-here
 VERCEL_TOKEN=your_vercel_token_here
 
 # Google OAuth Credentials (required for Google Docs integration)
+# Get these from: https://console.cloud.google.com/apis/credentials
+# Built-in token generator available at: /google-auth
 GOOGLE_CLIENT_ID=your-google-client-id-here
 GOOGLE_CLIENT_SECRET=your-google-client-secret-here
 
-# Google Auth Token Service URL (for generating OAuth tokens)
-# Deploy from: https://github.com/OmniGPT-Official/google-auth-token
-GOOGLE_AUTH_SERVICE_URL=https://your-google-auth-service.railway.app
+# OAuth Base URL (optional, for production deployment)
+# Set this to your deployed URL for OAuth callbacks
+# Example: https://your-app.railway.app
+# Leave unset for local development (defaults to http://localhost:PORT)
+OAUTH_BASE_URL=https://your-deployed-url.com
 
 # PostgreSQL Database (required for Knowledge Base)
 DATABASE_URL=postgresql://user:password@host:port/database

--- a/agno_agent.py
+++ b/agno_agent.py
@@ -55,43 +55,276 @@ agent_os = AgentOS(
 app = agent_os.get_app()
 
 # ---------------------------------------------------------------------------
-# Google Auth Service Integration
+# Google OAuth Token Generator (Built-in)
 # ---------------------------------------------------------------------------
-GOOGLE_AUTH_SERVICE_URL = os.getenv("GOOGLE_AUTH_SERVICE_URL")
+import json
+import secrets
+import requests as http_requests
+from urllib.parse import urlencode
+from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
+
+# Google OAuth Config
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
+PORT = int(os.getenv("PORT", 8000))
+BASE_URL = os.getenv("OAUTH_BASE_URL", f"http://localhost:{PORT}")
+REDIRECT_URI = f"{BASE_URL}/google-callback"
+
+SCOPES = [
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/spreadsheets",
+]
+
+AUTH_URI = "https://accounts.google.com/o/oauth2/auth"
+TOKEN_URI = "https://oauth2.googleapis.com/token"
+
+# In-memory storage for OAuth state and tokens
+oauth_state = {}
+latest_token = {}
 
 
-@app.get("/google-auth")
-async def google_auth_redirect():
-    """Redirect to Google Auth Token Generator service."""
-    from fastapi.responses import RedirectResponse, JSONResponse
+@app.get("/google-auth", response_class=HTMLResponse)
+async def google_auth_home():
+    """Google OAuth Token Generator home page."""
+    if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+        return HTMLResponse("""<!DOCTYPE html>
+<html><head><title>Configuration Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;text-align:center;">
+  <h1>Missing Google OAuth Credentials</h1>
+  <p>Please set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET environment variables.</p>
+  <a href="https://console.cloud.google.com/apis/credentials" style="color:#4ecca3;">Google Cloud Console</a>
+</body></html>""")
 
-    if not GOOGLE_AUTH_SERVICE_URL:
-        return JSONResponse(
-            {
-                "error": "GOOGLE_AUTH_SERVICE_URL not configured",
-                "message": "Set GOOGLE_AUTH_SERVICE_URL env var to your deployed google-auth-token service",
-                "repo": "https://github.com/OmniGPT-Official/google-auth-token"
-            },
-            status_code=503
-        )
-    return RedirectResponse(GOOGLE_AUTH_SERVICE_URL)
+    has_token = bool(latest_token)
+    token_section = ""
+    if has_token:
+        token_json = json.dumps(latest_token, separators=(',', ':'))
+        token_section = f'''
+        <div class="token-box">
+            <h2>Your Token (copy this for GOOGLE_DOCS_TOKEN env var):</h2>
+            <textarea id="token" readonly onclick="this.select()">{token_json}</textarea>
+            <button onclick="copyToken()">Copy to Clipboard</button>
+            <p class="success">Token generated successfully!</p>
+        </div>
+        <script>
+            function copyToken() {{
+                const textarea = document.getElementById('token');
+                textarea.select();
+                document.execCommand('copy');
+                alert('Token copied to clipboard!');
+            }}
+            console.log('GOOGLE_DOCS_TOKEN:', {json.dumps(token_json)});
+        </script>
+        '''
+
+    return f"""<!DOCTYPE html>
+<html><head><title>Google OAuth Token Generator</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; max-width: 900px; margin: 50px auto; padding: 20px; background: #1a1a2e; color: #eee; }}
+  .card {{ background: #16213e; padding: 32px; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,.3); }}
+  h1 {{ color: #4ecca3; margin-top: 0; }}
+  h2 {{ color: #4ecca3; font-size: 1.1em; margin-bottom: 10px; }}
+  .btn {{ display: inline-block; padding: 12px 28px; border-radius: 6px; text-decoration: none; color: #fff; font-weight: 600; margin: 8px 4px; border: none; cursor: pointer; font-size: 1em; }}
+  .btn.primary {{ background: #4ecca3; color: #1a1a2e; }}
+  .btn.primary:hover {{ background: #3db892; }}
+  .info {{ background: #0f3460; padding: 16px; border-radius: 8px; margin: 20px 0; }}
+  .info code {{ background: #1a1a2e; padding: 2px 8px; border-radius: 4px; }}
+  .token-box {{ background: #0f3460; padding: 20px; border-radius: 8px; margin: 20px 0; }}
+  .token-box textarea {{ width: 100%; height: 120px; background: #1a1a2e; color: #4ecca3; border: 1px solid #4ecca3; border-radius: 6px; padding: 12px; font-family: monospace; font-size: 12px; resize: vertical; }}
+  .token-box button {{ background: #4ecca3; color: #1a1a2e; border: none; padding: 10px 20px; border-radius: 6px; cursor: pointer; font-weight: 600; margin-top: 10px; }}
+  .token-box button:hover {{ background: #3db892; }}
+  .success {{ color: #4ecca3; font-weight: 600; }}
+  .warn {{ color: #f39c12; }}
+</style></head>
+<body><div class="card">
+  <h1>Google OAuth Token Generator</h1>
+
+  <div class="info">
+    <p><strong>Redirect URI:</strong> <code>{REDIRECT_URI}</code></p>
+    <p class="warn">Make sure this URI is added to your Google Cloud Console OAuth credentials!</p>
+  </div>
+
+  <a href="/google-auth/authorize" class="btn primary">Authorize with Google</a>
+
+  {token_section}
+
+  <div class="info" style="margin-top: 30px;">
+    <h3>How to use:</h3>
+    <ol>
+      <li>Click "Authorize with Google"</li>
+      <li>Sign in and grant permissions</li>
+      <li>Copy the JSON token displayed</li>
+      <li>Paste it as <code>GOOGLE_DOCS_TOKEN</code> in your env vars</li>
+    </ol>
+  </div>
+</div></body></html>"""
 
 
-@app.get("/google-auth/info")
-async def google_auth_info():
-    """Get Google Auth service configuration info."""
-    from fastapi.responses import JSONResponse
+@app.get("/google-auth/authorize")
+async def google_auth_authorize():
+    """Initiate Google OAuth flow."""
+    if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+        return JSONResponse({"error": "Google OAuth credentials not configured"}, status_code=503)
 
-    return JSONResponse({
-        "service_url": GOOGLE_AUTH_SERVICE_URL,
-        "configured": bool(GOOGLE_AUTH_SERVICE_URL),
-        "repo": "https://github.com/OmniGPT-Official/google-auth-token",
-        "endpoints": {
-            "authorize": f"{GOOGLE_AUTH_SERVICE_URL}/authorize" if GOOGLE_AUTH_SERVICE_URL else None,
-            "token": f"{GOOGLE_AUTH_SERVICE_URL}/token" if GOOGLE_AUTH_SERVICE_URL else None,
-            "health": f"{GOOGLE_AUTH_SERVICE_URL}/health" if GOOGLE_AUTH_SERVICE_URL else None,
-        }
+    state = secrets.token_urlsafe(32)
+    oauth_state["current"] = state
+
+    params = {
+        "client_id": GOOGLE_CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "state": state,
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+
+    url = f"{AUTH_URI}?{urlencode(params)}"
+    print(f"\n-> Redirecting to Google OAuth ({state[:12]}...)")
+    return RedirectResponse(url)
+
+
+@app.get("/google-callback")
+async def google_callback(code: str = None, state: str = None, error: str = None):
+    """Handle Google OAuth callback."""
+    global latest_token
+
+    if error:
+        return HTMLResponse(f"""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;text-align:center;">
+  <h1>Authorization Error</h1>
+  <p>{error}</p>
+  <a href="/google-auth" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
+
+    if state != oauth_state.get("current"):
+        return HTMLResponse("""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;text-align:center;">
+  <h1>Invalid State</h1>
+  <p>CSRF check failed. Please try again.</p>
+  <a href="/google-auth" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
+
+    if not code:
+        return HTMLResponse("""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;text-align:center;">
+  <h1>No Code</h1>
+  <p>No authorization code received.</p>
+  <a href="/google-auth" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
+
+    print(f"\n-> Callback received, exchanging code...")
+
+    # Exchange code for tokens
+    resp = http_requests.post(TOKEN_URI, data={
+        "code": code,
+        "client_id": GOOGLE_CLIENT_ID,
+        "client_secret": GOOGLE_CLIENT_SECRET,
+        "redirect_uri": REDIRECT_URI,
+        "grant_type": "authorization_code",
     })
+
+    if resp.status_code != 200:
+        return HTMLResponse(f"""<!DOCTYPE html>
+<html><head><title>Error</title></head>
+<body style="font-family:system-ui;background:#1a1a2e;color:#e74c3c;padding:40px;">
+  <h1>Token Exchange Failed</h1>
+  <pre style="background:#0f3460;padding:20px;border-radius:8px;color:#eee;">{resp.text}</pre>
+  <a href="/google-auth" style="color:#4ecca3;">Try Again</a>
+</body></html>""")
+
+    tokens = resp.json()
+
+    # Build the token object
+    latest_token = {
+        "token": tokens["access_token"],
+        "refresh_token": tokens.get("refresh_token"),
+        "token_uri": TOKEN_URI,
+        "client_id": GOOGLE_CLIENT_ID,
+        "client_secret": GOOGLE_CLIENT_SECRET,
+        "scopes": SCOPES,
+    }
+
+    token_json = json.dumps(latest_token, separators=(',', ':'))
+    token_pretty = json.dumps(latest_token, indent=2)
+
+    print(f"\n{'='*60}")
+    print("TOKEN GENERATED - Copy this for GOOGLE_DOCS_TOKEN:")
+    print(f"{'='*60}")
+    print(token_json)
+    print(f"{'='*60}\n")
+
+    return f"""<!DOCTYPE html>
+<html><head><title>Token Generated!</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; max-width: 900px; margin: 50px auto; padding: 20px; background: #1a1a2e; color: #eee; }}
+  .card {{ background: #16213e; padding: 32px; border-radius: 12px; }}
+  h1 {{ color: #4ecca3; }}
+  .token-box {{ background: #0f3460; padding: 20px; border-radius: 8px; margin: 20px 0; }}
+  .token-box label {{ color: #4ecca3; font-weight: 600; display: block; margin-bottom: 8px; }}
+  .token-box textarea {{ width: 100%; background: #1a1a2e; color: #4ecca3; border: 2px solid #4ecca3; border-radius: 6px; padding: 12px; font-family: monospace; font-size: 12px; resize: vertical; }}
+  .minified {{ height: 80px; }}
+  .pretty {{ height: 200px; }}
+  button {{ background: #4ecca3; color: #1a1a2e; border: none; padding: 12px 24px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 1em; margin: 5px; }}
+  button:hover {{ background: #3db892; }}
+  .success {{ color: #4ecca3; font-size: 1.2em; }}
+  .info {{ background: #0f3460; padding: 16px; border-radius: 8px; margin: 20px 0; }}
+</style>
+<script>
+  function copyMinified() {{
+    document.getElementById('minified').select();
+    document.execCommand('copy');
+    alert('Minified token copied!');
+  }}
+  function copyPretty() {{
+    document.getElementById('pretty').select();
+    document.execCommand('copy');
+    alert('Pretty token copied!');
+  }}
+  console.log('GOOGLE_DOCS_TOKEN (minified):', {json.dumps(token_json)});
+</script>
+</head>
+<body><div class="card">
+  <h1>Token Generated Successfully!</h1>
+  <p class="success">Your Google OAuth token is ready.</p>
+
+  <div class="token-box">
+    <label>Minified (for env var):</label>
+    <textarea id="minified" class="minified" readonly onclick="this.select()">{token_json}</textarea>
+    <button onclick="copyMinified()">Copy Minified</button>
+  </div>
+
+  <div class="token-box">
+    <label>Pretty (for reading):</label>
+    <textarea id="pretty" class="pretty" readonly onclick="this.select()">{token_pretty}</textarea>
+    <button onclick="copyPretty()">Copy Pretty</button>
+  </div>
+
+  <div class="info">
+    <h3>Next steps:</h3>
+    <ol>
+      <li>Copy the <strong>minified</strong> token above</li>
+      <li>Add it as <code>GOOGLE_DOCS_TOKEN</code> environment variable</li>
+      <li>Redeploy your service</li>
+    </ol>
+  </div>
+
+  <a href="/google-auth" style="color:#4ecca3;">← Back to Home</a>
+</div></body></html>"""
+
+
+@app.get("/google-auth/token")
+async def get_google_token():
+    """Return the latest token as JSON (for API access)."""
+    if not latest_token:
+        return JSONResponse({"error": "No token generated yet. Visit /google-auth first."}, status_code=404)
+    return JSONResponse(latest_token)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add complete OAuth flow directly in Agent-Os at /google-auth
- Remove external service dependency
- Add /google-auth/authorize endpoint for OAuth flow
- Add /google-callback endpoint for token exchange
- Add /google-auth/token endpoint for API access
- Display token on screen with copy-to-clipboard functionality
- Update .env.example with OAUTH_BASE_URL for production deployments
- Token printed to console and displayed in browser UI

Users can now generate Google OAuth tokens directly from Agent-Os without needing a separate service.