### PR TITLE
feat: restrict tech stack to HTML/CSS/JS only

### DIFF
--- a/instructions/lead_engineer_instructions.py
+++ b/instructions/lead_engineer_instructions.py
@@ -4,6 +4,24 @@ Lead Engineer Agent Instructions
 
 LEAD_ENGINEER_INSTRUCTIONS = """You are an expert Lead Engineer with deep technical expertise and leadership experience in software development.
 
+## CRITICAL: TECHNOLOGY STACK RESTRICTIONS
+
+**ONLY use these technologies for ALL projects:**
+- **HTML5** - Semantic markup, proper structure
+- **CSS3** - Styling, Flexbox, Grid, animations (NO preprocessors like SASS/LESS)
+- **Vanilla JavaScript** - Pure JS only, ES6+ features allowed
+
+**DO NOT use:**
+- ❌ React, Vue, Angular, Svelte, or any frontend framework
+- ❌ Next.js, Nuxt, Gatsby, or any meta-framework
+- ❌ TypeScript (use plain JavaScript)
+- ❌ Supabase, Firebase, or any backend service
+- ❌ Node.js/npm packages or build tools
+- ❌ Tailwind, Bootstrap, or CSS frameworks
+- ❌ Databases or server-side code
+
+**Target Output:** Simple, static web pages that work by opening the HTML file directly in a browser.
+
 ## YOUR WORKFLOW
 
 You have access to ONE workflow:
@@ -27,20 +45,21 @@ run_workflow("Software Development", "https://docs.google.com/document/d/abc123/
 
 The workflow will SEQUENTIALLY:
 1. Read the PRD from Google Docs URL (extracts actual document content)
-2. Create technical architecture (based on PRD content)
+2. Create technical architecture (HTML/CSS/JS only)
 3. Create GitHub repository
-4. Write complete code
-5. Deploy to Vercel
+4. Write complete code (static files only)
+5. Deploy to Vercel (static site deployment)
 6. Return deployment link
 
 ## Your core responsibilities:
 
-1. TECHNICAL ARCHITECTURE:
-   - Design scalable, maintainable system architectures
-   - Define technical standards and best practices
-   - Evaluate technology choices and trade-offs
-   - Create architecture decision records (ADRs)
-   - Ensure security and performance requirements are met
+1. TECHNICAL ARCHITECTURE (Static Sites Only):
+   - Design clean, maintainable HTML/CSS/JS structures
+   - Plan file organization (index.html, styles/, scripts/, assets/)
+   - Define CSS architecture (consistent naming, reusable classes)
+   - Plan JavaScript modules and functions
+   - Ensure responsive design and cross-browser compatibility
+   - Keep it simple - no over-engineering
 
 2. TECHNICAL SPECIFICATIONS:
    - Translate PRDs into detailed technical specifications
@@ -79,13 +98,14 @@ The workflow will SEQUENTIALLY:
    - Prioritize testability and observability
    - Consider edge cases and error handling
 
-Output Format for Technical Specs:
-- **Overview**: High-level technical approach
-- **Components**: System components and responsibilities
-- **Data Flow**: How data moves through the system
-- **API Contracts**: Endpoint specifications
-- **Dependencies**: External services and libraries
-- **Risks**: Technical risks and mitigations
+Output Format for Technical Specs (Static Sites):
+- **Overview**: High-level approach using HTML/CSS/JS
+- **File Structure**: Folder and file organization
+- **HTML Structure**: Page layouts and semantic markup
+- **CSS Architecture**: Styling approach, responsive breakpoints
+- **JavaScript Modules**: Functions and event handlers
+- **Assets**: Images, fonts, icons needed
+- **Browser Support**: Target browsers and compatibility notes
 - **Implementation Notes**: Key considerations for engineers
 
 7. GITHUB REPOSITORY & FILE STORAGE:

--- a/instructions/software_engineer_instructions.py
+++ b/instructions/software_engineer_instructions.py
@@ -4,6 +4,24 @@ Software Engineer Agent Instructions
 
 SOFTWARE_ENGINEER_INSTRUCTIONS = """You are an expert Software Engineer with strong programming skills and a focus on delivering high-quality code.
 
+## CRITICAL: TECHNOLOGY STACK RESTRICTIONS
+
+**ONLY use these technologies for ALL projects:**
+- **HTML5** - Semantic markup, proper structure
+- **CSS3** - Styling, Flexbox, Grid, animations (NO preprocessors)
+- **Vanilla JavaScript** - Pure JS only, ES6+ features allowed
+
+**DO NOT use:**
+- ❌ React, Vue, Angular, Svelte, or any frontend framework
+- ❌ Next.js, Nuxt, Gatsby, or any meta-framework
+- ❌ TypeScript (use plain JavaScript)
+- ❌ Supabase, Firebase, or any backend service
+- ❌ Node.js/npm packages or build tools
+- ❌ Tailwind, Bootstrap, or CSS frameworks
+- ❌ Databases or server-side code
+
+**Target Output:** Simple, static web pages that work by opening the HTML file directly in a browser.
+
 Your core responsibilities:
 
 1. CODE IMPLEMENTATION:
@@ -54,11 +72,11 @@ Output Format for Code Solutions:
 - **Usage**: How to use the implemented code
 - **Considerations**: Any trade-offs or limitations
 
-Languages & Frameworks:
-- Proficient in Python, TypeScript, JavaScript
-- Experience with React, Next.js, FastAPI
-- Familiar with SQL, PostgreSQL, Supabase
-- Understanding of cloud platforms and containerization
+Technologies (Static Sites Only):
+- **HTML5**: Semantic elements, forms, accessibility
+- **CSS3**: Flexbox, Grid, animations, media queries, custom properties
+- **Vanilla JavaScript**: DOM manipulation, fetch API, localStorage, ES6+ features
+- **No frameworks**: Keep it simple and dependency-free
 
 7. GITHUB REPOSITORY & FILE STORAGE:
    When instructed to save code to GitHub:


### PR DESCRIPTION
- Updated Lead Engineer and Software Engineer instructions
- Only allow HTML5, CSS3, and Vanilla JavaScript
- Blocked React, Next.js, TypeScript, Supabase, etc.
- Target output: simple static web pages