### PR TITLE
fix: remove timeouts and ensure Vercel SDK installed in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ RUN apt-get update && apt-get install -y curl && \
     apt-get install -y nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements and install
+# Copy requirements and install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy app
 COPY . .
+
+# Install Vercel SDK for deployment tool
+RUN cd tests/vercel_mcp && npm install
 
 # Expose port
 EXPOSE 8000

--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,8 @@
 [build]
-builder = "NIXPACKS"
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "sh -c 'uvicorn agno_agent:app --host 0.0.0.0 --port ${PORT:-8000}'"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
 

--- a/tests/vercel_mcp/deploy.js
+++ b/tests/vercel_mcp/deploy.js
@@ -22,7 +22,6 @@ const PROJECT_NAME     = process.env.DEPLOY_PROJECT_NAME || 'crumble-bakery-depl
 const GITHUB_ORG       = process.env.DEPLOY_GITHUB_ORG   || 'Muhammad-Anique';
 const GITHUB_REPO      = process.env.DEPLOY_GITHUB_REPO  || '--crumble-bakery--softwar-33438';
 const POLL_INTERVAL_MS = 5_000;   // 5 s
-const TIMEOUT_MS       = 300_000; // 5 min
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -39,7 +38,6 @@ async function sleep(ms) {
 // Poll until READY
 // ---------------------------------------------------------------------------
 async function waitForReady(vercel, deploymentId) {
-  const deadline = Date.now() + TIMEOUT_MS;
   let attempt = 0;
 
   while (true) {
@@ -59,9 +57,7 @@ async function waitForReady(vercel, deploymentId) {
       throw new Error(`Deployment ended with state=${state}`);
     }
 
-    if (Date.now() > deadline) {
-      throw new Error(`Timed out after ${TIMEOUT_MS / 1000}s — last state: ${state}`);
-    }
+    // No timeout - wait indefinitely for deployment to complete
 
     await sleep(POLL_INTERVAL_MS);
   }

--- a/tools/vercel_deploy_tools.py
+++ b/tools/vercel_deploy_tools.py
@@ -65,12 +65,9 @@ class VercelDeployTools(Toolkit):
                 ["node", "deploy.js"],
                 capture_output=True,
                 text=True,
-                timeout=360,
                 cwd=_DEPLOY_SCRIPT_DIR,
                 env=env,
             )
-        except subprocess.TimeoutExpired:
-            return json.dumps({"error": True, "message": "deploy.js timed out after 360s"})
         except FileNotFoundError:
             return json.dumps({"error": True, "message": "node not found — is Node.js installed?"})
 

--- a/workflows/software_development_workflow.py
+++ b/workflows/software_development_workflow.py
@@ -54,9 +54,10 @@ _state = ImplementationState()
 # HELPER FUNCTIONS
 # ============================================================================
 
-def _run_with_heartbeat(coro, step_name: str, timeout_seconds: int = 120):
-    """Run coroutine in a background thread with heartbeat logging and timeout.
-    Returns the agent result, or None if timed out / errored."""
+def _run_with_heartbeat(coro, step_name: str, timeout_seconds: int = 0):
+    """Run coroutine in a background thread with heartbeat logging.
+    If timeout_seconds <= 0, no timeout is applied (waits indefinitely).
+    Returns the agent result, or None if errored."""
     result_holder = [None]
     error_holder = [None]
     done_event = threading.Event()
@@ -74,12 +75,13 @@ def _run_with_heartbeat(coro, step_name: str, timeout_seconds: int = 120):
     thread = threading.Thread(target=_execute, daemon=True)
     thread.start()
 
-    # Heartbeat every 10s so you can see progress instead of a frozen screen
+    # Heartbeat every 30s so you can see progress instead of a frozen screen
     elapsed = 0
     while not done_event.wait(timeout=30):
         elapsed += 30
         _log("⏳", step_name, f"Working... ({elapsed}s)")
-        if elapsed >= timeout_seconds:
+        # Only apply timeout if timeout_seconds > 0
+        if timeout_seconds > 0 and elapsed >= timeout_seconds:
             _log("⏰", step_name, f"Timed out after {timeout_seconds}s")
             return None
 
@@ -307,7 +309,7 @@ Output ONLY the JavaScript code, nothing else. Start with // or 'use strict'"""
     if not prompt:
         return ""
 
-    result = _run_with_heartbeat(agent.arun(prompt), f"DEV-{file_type.upper()}", timeout_seconds=180)
+    result = _run_with_heartbeat(agent.arun(prompt), f"DEV-{file_type.upper()}", timeout_seconds=0)
     if result and result.content:
         return _extract_code(result.content)
     return ""
@@ -522,7 +524,7 @@ DO NOT make multiple calls. DO NOT guess the URL. Use the tool's response.
 """
 
     _log("🤖", "DEPLOY", "Asking agent to deploy...")
-    result = _run_with_heartbeat(software_engineer_agent.arun(prompt), "DEPLOY", timeout_seconds=600)
+    result = _run_with_heartbeat(software_engineer_agent.arun(prompt), "DEPLOY", timeout_seconds=0)
 
     if result is None:
         _log("❌", "DEPLOY", "Agent timed out or failed")


### PR DESCRIPTION
- Remove all timeouts from development and deployment steps
- Add npm install for @vercel/sdk in Dockerfile
- Align railway.toml to use DOCKERFILE builder (was NIXPACKS)
- Remove subprocess timeout in vercel_deploy_tools.py
- Remove polling timeout in deploy.js