### PR TITLE
fix: increase max_tokens to prevent code truncation

### DIFF
--- a/agents/lead_engineer.py
+++ b/agents/lead_engineer.py
@@ -30,7 +30,7 @@ supabase_mcp = MCPTools(
 lead_engineer_agent = Agent(
     name="Lead Engineer Agent",
     role="Designs technical architecture, creates technical specifications, provides code review guidance, and offers technical leadership on implementation approaches.",
-    model=OpenRouter(id="google/gemini-3-flash-preview"),
+    model=OpenRouter(id="google/gemini-3-flash-preview", max_tokens=16384),
     db=SqliteDb(db_file="agno.db"),
     add_history_to_context=True,
     num_history_messages=20,

--- a/agents/product_lead.py
+++ b/agents/product_lead.py
@@ -17,7 +17,7 @@ from tools.google_docs_tools import GoogleDocsTools
 product_lead_agent = Agent(
     name="Product Lead",
     role="Conducts product discovery, creates PRDs/Feature Specs in Google Docs, then delegates to Lead Engineer for implementation.",
-    model=OpenRouter(id="google/gemini-3-flash-preview"),
+    model=OpenRouter(id="google/gemini-3-flash-preview", max_tokens=16384),
     db=SqliteDb(db_file="agno.db"),
     add_history_to_context=True,
     num_history_messages=20,  # Keep last 20 messages in context

--- a/agents/security_engineer.py
+++ b/agents/security_engineer.py
@@ -19,7 +19,7 @@ github_tools = GitHubTools()
 security_engineer_agent = Agent(
     name="Security Engineer Agent",
     role="Reviews code for security vulnerabilities, ensures secure coding practices, and provides security guidance on implementations.",
-    model=OpenRouter(id="google/gemini-3-flash-preview"),
+    model=OpenRouter(id="google/gemini-3-flash-preview", max_tokens=8192),
     db=SqliteDb(db_file="agno.db"),
     add_history_to_context=True,
     num_history_messages=20,

--- a/agents/software_engineer.py
+++ b/agents/software_engineer.py
@@ -28,7 +28,7 @@ vercel_deploy_tools = VercelDeployTools()
 software_engineer_agent = Agent(
     name="Software Engineer Agent",
     role="Implements code, fixes bugs, writes tests, and creates code documentation. Handles version control and follows coding best practices.",
-    model=OpenRouter(id="google/gemini-3-flash-preview"),
+    model=OpenRouter(id="google/gemini-3-flash-preview", max_tokens=16384),
     db=SqliteDb(db_file="agno.db"),
     add_history_to_context=True,
     num_history_messages=20,

--- a/agents/vercel_deployer.py
+++ b/agents/vercel_deployer.py
@@ -45,7 +45,7 @@ vercel_deploy_tools = VercelDeployTools()
 vercel_deployer_agent = Agent(
     name="Vercel Deployer",
     role="Deploys GitHub repositories to Vercel and returns the live preview URL.",
-    model=OpenRouter(id="google/gemini-2.0-flash-001"),
+    model=OpenRouter(id="google/gemini-2.0-flash-001", max_tokens=4096),
     markdown=True,
     instructions=VERCEL_DEPLOYER_INSTRUCTIONS,
     tools=[vercel_deploy_tools],

--- a/teams/product_team.py
+++ b/teams/product_team.py
@@ -44,7 +44,7 @@ def run_software_development(input_data: str) -> str:
 
 product_team = Team(
     name="Product Development Team",
-    model=OpenRouter(id="google/gemini-3-flash-preview"),
+    model=OpenRouter(id="google/gemini-3-flash-preview", max_tokens=16384),
     db=SqliteDb(db_file="agno.db"),
     members=[
         product_lead_agent,


### PR DESCRIPTION
OpenRouter defaults to 1024 max_tokens which truncates code output. Increased limits: 16384 for code-generating agents, 8192 for security, 4096 for deployer.