### PR TITLE
fix: remove startCommand so Dockerfile CMD handles $PORT expansion

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,6 @@
   },
   "deploy": {
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10,
-    "startCommand": "python -m uvicorn agno_agent:app --host 0.0.0.0"
+    "restartPolicyMaxRetries": 10
   }
 }

--- a/railway.toml
+++ b/railway.toml
@@ -5,7 +5,6 @@ dockerfilePath = "Dockerfile"
 [deploy]
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
-startCommand = "python -m uvicorn agno_agent:app --host 0.0.0.0 --port $PORT"
 
 [env]
 PYTHONUNBUFFERED = "1"


### PR DESCRIPTION
Railway's startCommand doesn't run through a shell, so $PORT is passed as a literal string. The Dockerfile CMD already uses /bin/sh -c which properly expands $PORT at runtime.