### PR TITLE
fix: convert deploy.js to ESM to fix @vercel/sdk import error

### DIFF
--- a/tests/vercel_mcp/deploy.js
+++ b/tests/vercel_mcp/deploy.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Vercel deploy tool — uses the official @vercel/sdk.
  *
@@ -12,7 +10,7 @@
  * Requires: VERCEL_TOKEN env var
  */
 
-const { Vercel } = require('@vercel/sdk');
+import { Vercel } from '@vercel/sdk';
 
 // ---------------------------------------------------------------------------
 // Config

--- a/tests/vercel_mcp/package.json
+++ b/tests/vercel_mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vercel-deploy-tool",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@vercel/sdk": "latest"
   }


### PR DESCRIPTION
@vercel/sdk is ESM-only and cannot be loaded with require(). Added "type": "module" to package.json and changed require() to import.