### PR TITLE
Add Supabase migrations for per-user OAuth

### DIFF
--- a/supabase/migrations/20260207033451_create_user_oauth_connections.sql
+++ b/supabase/migrations/20260207033451_create_user_oauth_connections.sql
@@ -1,0 +1,57 @@
+-- Create user_oauth_connections table for per-user OAuth token storage
+create table public.user_oauth_connections (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    provider text not null,                    -- 'google_sheets', 'google_gmail', 'slack', 'notion'
+    provider_account_id text not null,         -- unique id from provider (e.g. email)
+    account_label text,                        -- user-friendly name
+    access_token text not null,
+    refresh_token text,
+    token_uri text,
+    scopes text[] default '{}',
+    expires_at timestamptz,
+    metadata jsonb default '{}',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint uq_user_provider_account unique (user_id, provider, provider_account_id)
+);
+
+-- Index for fast lookups by user + provider
+create index idx_user_oauth_connections_user_provider
+    on public.user_oauth_connections (user_id, provider);
+
+-- Auto-update updated_at on row changes
+create or replace function public.update_updated_at_column()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_user_oauth_connections_updated_at
+    before update on public.user_oauth_connections
+    for each row
+    execute function public.update_updated_at_column();
+
+-- RLS: users can only access their own rows
+alter table public.user_oauth_connections enable row level security;
+
+create policy "Users can view their own connections"
+    on public.user_oauth_connections for select
+    using (auth.uid() = user_id);
+
+create policy "Users can insert their own connections"
+    on public.user_oauth_connections for insert
+    with check (auth.uid() = user_id);
+
+create policy "Users can update their own connections"
+    on public.user_oauth_connections for update
+    using (auth.uid() = user_id);
+
+create policy "Users can delete their own connections"
+    on public.user_oauth_connections for delete
+    using (auth.uid() = user_id);
+
+-- Grant access to authenticated users (RLS enforces row-level access)
+grant select, insert, update, delete on public.user_oauth_connections to authenticated;

--- a/supabase/migrations/20260209022943_add_oauth_provider_enum.sql
+++ b/supabase/migrations/20260209022943_add_oauth_provider_enum.sql
@@ -1,0 +1,12 @@
+-- Create enum type for OAuth providers
+CREATE TYPE public.oauth_provider AS ENUM (
+    'google_sheets',
+    'google_gmail',
+    'slack',
+    'notion'
+);
+
+-- Convert provider column from text to enum
+ALTER TABLE public.user_oauth_connections
+    ALTER COLUMN provider TYPE public.oauth_provider
+    USING provider::public.oauth_provider;


### PR DESCRIPTION
## Summary
- Adds `supabase/migrations/` directory with migration files synced from agent_os PR #6
- Creates `user_oauth_connections` table for storing per-user Google OAuth tokens (Sheets, Gmail, Slack, Notion)
- Includes RLS policies so users can only access their own credentials
- Adds `oauth_provider` enum constraint for data integrity

## Test plan
- [ ] Review migration SQL matches agent_os source
- [ ] Verify migrations apply cleanly on the shared Supabase instance