### PR TITLE
Fix: Support DATABASE_URL environment variable for database connection

### DIFF
--- a/db.py
+++ b/db.py
@@ -8,12 +8,27 @@ from os import getenv
 
 from agno.db.postgres import PostgresDb
 
-# Get Supabase credentials from environment
-SUPABASE_DB_URL = getenv("SUPABASE_DB_URL")
-if not SUPABASE_DB_URL:
+# Get database URL from environment
+# Try multiple env var names for compatibility:
+# 1. DATABASE_URL (standard convention, used by Railway/Vercel/Heroku)
+# 2. SUPABASE_DB_URL (legacy, for backwards compatibility)
+# 3. Construct from SUPABASE_PROJECT + SUPABASE_PASSWORD (fallback)
+db_url = getenv("DATABASE_URL") or getenv("SUPABASE_DB_URL")
+
+if not db_url:
+    # Fallback: construct from individual credentials
     SUPABASE_PROJECT = getenv("SUPABASE_PROJECT")
     SUPABASE_PASSWORD = getenv("SUPABASE_PASSWORD")
-    SUPABASE_DB_URL = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}:5432/postgres"
+
+    if SUPABASE_PROJECT and SUPABASE_PASSWORD:
+        db_url = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}.supabase.co:5432/postgres"
+    else:
+        raise ValueError(
+            "Database configuration missing. Set one of:\n"
+            "  - DATABASE_URL (recommended)\n"
+            "  - SUPABASE_DB_URL\n"
+            "  - Both SUPABASE_PROJECT and SUPABASE_PASSWORD"
+        )
 
 # Setup Supabase PostgreSQL database
-db = PostgresDb(db_url=SUPABASE_DB_URL)
+db = PostgresDb(db_url=db_url)


### PR DESCRIPTION
**Problem:**
- Deployment failing with error: "could not translate host name 'db.None'"
- Code only looked for SUPABASE_DB_URL, but Railway/standard deployments use DATABASE_URL
- Fallback to SUPABASE_PROJECT was creating "db.None" when env var not set

**Solution:**
- Try DATABASE_URL first (standard convention)
- Fall back to SUPABASE_DB_URL (backwards compatibility)
- Fall back to SUPABASE_PROJECT + SUPABASE_PASSWORD construction
- Raise clear error if none are set
- Fixed typo in fallback URL (.supabase.co domain)

**Impact:**
- Fixes deployment on Railway (uses DATABASE_URL by default)
- Maintains backwards compatibility with SUPABASE_DB_URL
- Better error message when configuration is missing

**Testing:**
Set DATABASE_URL in Railway and deployment should succeed