### PR TITLE
Fix startup crash by lazy-initializing knowledge base

### DIFF
--- a/utils/knowledge_base.py
+++ b/utils/knowledge_base.py
@@ -13,29 +13,8 @@ from agno.vectordb.pgvector import PgVector
 from db import SUPABASE_DB_URL
 
 
-# Initialize PostgreSQL database for content tracking
-contents_db = PostgresDb(
-    db_url=SUPABASE_DB_URL,
-    knowledge_table="knowledge_contents"
-)
-
-
-# Initialize PgVector for embeddings
-vector_db = PgVector(
-    table_name="knowledge_vectors",
-    db_url=SUPABASE_DB_URL
-)
-
-
-# Initialize Agno Knowledge
-knowledge = Knowledge(
-    vector_db=vector_db,
-    contents_db=contents_db,
-)
-
-
 # =========================================================================
-# SINGLETON INSTANCE
+# SINGLETON INSTANCE (lazy-initialized to avoid DB connection at import time)
 # =========================================================================
 
 _knowledge_base_instance = None
@@ -45,5 +24,16 @@ def get_knowledge_base() -> Knowledge:
     """Get or create the singleton knowledge base instance."""
     global _knowledge_base_instance
     if _knowledge_base_instance is None:
-        _knowledge_base_instance = knowledge
+        contents_db = PostgresDb(
+            db_url=SUPABASE_DB_URL,
+            knowledge_table="knowledge_contents"
+        )
+        vector_db = PgVector(
+            table_name="knowledge_vectors",
+            db_url=SUPABASE_DB_URL
+        )
+        _knowledge_base_instance = Knowledge(
+            vector_db=vector_db,
+            contents_db=contents_db,
+        )
     return _knowledge_base_instance


### PR DESCRIPTION
## Summary
- App was crashing on startup because the knowledge base tried to connect to the database at import time
- Moved initialization inside `get_knowledge_base()` so the DB connection only happens when actually needed
- This prevents startup failures when the database is temporarily unreachable

## Test plan
- [ ] Deploy and verify the app starts without crashing
- [ ] Verify knowledge base still works when queried by agents