### PR TITLE
Revert unintended db.py changes from PR #65

### DIFF
--- a/db.py
+++ b/db.py
@@ -5,31 +5,15 @@ Uses the same pattern as agent_os/main.py.
 """
 
 from os import getenv
-import sys
 
 from agno.db.postgres import PostgresDb
 
-# Get database URL from environment
-# Try multiple env var names for compatibility:
-# 1. DATABASE_URL (standard convention, used by Railway/Vercel/Heroku)
-# 2. SUPABASE_DB_URL (legacy, for backwards compatibility)
-# 3. Construct from SUPABASE_PROJECT + SUPABASE_PASSWORD (fallback)
-db_url = getenv("DATABASE_URL") or getenv("SUPABASE_DB_URL")
-
-if not db_url:
-    # Fallback: construct from individual credentials
+# Get Supabase credentials from environment
+SUPABASE_DB_URL = getenv("SUPABASE_DB_URL")
+if not SUPABASE_DB_URL:
     SUPABASE_PROJECT = getenv("SUPABASE_PROJECT")
     SUPABASE_PASSWORD = getenv("SUPABASE_PASSWORD")
-
-    if SUPABASE_PROJECT and SUPABASE_PASSWORD:
-        db_url = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}.supabase.co:5432/postgres"
-    else:
-        print("ERROR: No database connection configured!", file=sys.stderr)
-        print("Please set one of the following:", file=sys.stderr)
-        print("  - DATABASE_URL (recommended)", file=sys.stderr)
-        print("  - SUPABASE_DB_URL", file=sys.stderr)
-        print("  - SUPABASE_PROJECT + SUPABASE_PASSWORD", file=sys.stderr)
-        sys.exit(1)
+    SUPABASE_DB_URL = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}:5432/postgres"
 
 # Setup Supabase PostgreSQL database
-db = PostgresDb(db_url=db_url)
+db = PostgresDb(db_url=SUPABASE_DB_URL)


### PR DESCRIPTION
## Summary
- PR #65 (Email Follow-Up Workflow) accidentally modified `db.py`, renaming the `SUPABASE_DB_URL` variable to `db_url`
- This broke the import in `utils/knowledge_base.py` which depends on `SUPABASE_DB_URL`, causing a deploy crash
- This reverts `db.py` to its previous working state