### PR TITLE
Revert DATABASE_URL support from db.py

### DIFF
--- a/db.py
+++ b/db.py
@@ -8,22 +8,12 @@ from os import getenv
 
 from agno.db.postgres import PostgresDb
 
-# Get database URL from environment
-# Try multiple env var names for Railway/Vercel/Heroku compatibility:
-# 1. DATABASE_URL (standard for Railway/Vercel/Heroku)
-# 2. SUPABASE_DB_URL (legacy/explicit Supabase)
-# 3. Construct from SUPABASE_PROJECT + SUPABASE_PASSWORD (fallback)
-db_url = getenv("DATABASE_URL") or getenv("SUPABASE_DB_URL")
-
-if not db_url:
-    # Fallback: construct from individual credentials
+# Get Supabase credentials from environment
+SUPABASE_DB_URL = getenv("SUPABASE_DB_URL")
+if not SUPABASE_DB_URL:
     SUPABASE_PROJECT = getenv("SUPABASE_PROJECT")
     SUPABASE_PASSWORD = getenv("SUPABASE_PASSWORD")
-    if SUPABASE_PROJECT and SUPABASE_PASSWORD:
-        db_url = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}.supabase.co:5432/postgres"
-
-# Export for backward compatibility (used by knowledge_base.py)
-SUPABASE_DB_URL = db_url
+    SUPABASE_DB_URL = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}:5432/postgres"
 
 # Setup Supabase PostgreSQL database
-db = PostgresDb(db_url=db_url)
+db = PostgresDb(db_url=SUPABASE_DB_URL)


### PR DESCRIPTION
## Summary
- Reverts the DATABASE_URL changes from PR #68 (commit 449ce78)
- Restores the original Supabase-only database configuration in `db.py`
- `db.py` now reads `SUPABASE_DB_URL` or constructs from `SUPABASE_PROJECT` + `SUPABASE_PASSWORD` as before

## Test plan
- [ ] Verify agents connect to the database using `SUPABASE_DB_URL`
- [ ] Verify fallback construction from `SUPABASE_PROJECT` + `SUPABASE_PASSWORD` works