### PR TITLE
Add per-user API key storage and Supabase Manager agent

### DIFF
--- a/agno_agent.py
+++ b/agno_agent.py
@@ -23,6 +23,7 @@ from content_creation import (
 )
 from email_followup import email_followup_agent
 from gmail_sheets_agent import gmail_sheets_agent
+from supabase_manager import supabase_manager_agent
 from workflows.email_followup_workflow_working import email_followup_workflow
 from workflows.outbound_calling_workflow import outbound_calling_workflow, simple_calling_workflow
 from agents.calling_agents import (
@@ -55,6 +56,7 @@ agent_os = AgentOS(
         content_writer,  # Content Creation Team
         email_followup_agent,  # Email Follow-Up Agent (OAuth-enabled)
         gmail_sheets_agent,  # Gmail & Sheets Agent (OAuth-enabled, Claude)
+        supabase_manager_agent,  # Supabase Manager (MCP-enabled)
         lead_reader_agent,  # Outbound Calling: Lead Reader
         calling_coordinator_agent,  # Outbound Calling: Calling Coordinator
         results_logger_agent,  # Outbound Calling: Results Logger

--- a/docs/api-key-storage.md
+++ b/docs/api-key-storage.md
@@ -1,0 +1,72 @@
+# Architecture Decision Record: Per-User API Key Storage
+
+## Problem
+
+Some tools (ElevenLabs, Vercel, Supabase Management API, etc.) authenticate via simple API keys or Personal Access Tokens (PATs) rather than OAuth flows. These credentials need to be stored per-user, but the existing `user_oauth_connections` table is designed for OAuth — it carries refresh tokens, scopes, token URIs, and provider account IDs that don't apply to plain API keys.
+
+## Decision
+
+Create a separate `user_api_keys` table for storing per-user API keys and PATs. This keeps the schema clean — each table serves one credential model — and avoids nullable columns or overloaded fields.
+
+## Schema Design
+
+See `supabase/migrations/*_create_user_api_keys.sql` for the full schema.
+
+### Column rationale
+
+- **`provider text`** (not enum): Adding a new provider requires only an INSERT, not a DDL migration. This avoids the `ALTER TYPE` ceremony used by the OAuth table's enum.
+- **Unique constraint on `(user_id, provider)`**: One key per provider per user. If a provider needs multiple keys in the future, this can be relaxed.
+- **`label text`**: Optional friendly name (e.g. "My ElevenLabs Pro key") for display in a settings UI.
+- **`metadata jsonb`**: Extensible per-provider data. Could store plan tier, key permissions, or expiration info.
+
+### Relationship to `user_oauth_connections`
+
+| Credential type | Table | Example providers |
+|-----------------|-------|-------------------|
+| OAuth (access + refresh tokens, scopes) | `user_oauth_connections` | Google Sheets, Gmail, Slack |
+| API key / PAT (single secret string) | `user_api_keys` | ElevenLabs, Vercel, Supabase |
+
+Use `user_oauth_connections` when the provider requires an OAuth flow. Use `user_api_keys` when the user pastes in a key from the provider's dashboard.
+
+## Security Model
+
+- **Service role key** is used server-side in `api_key_store.py` (via the shared `get_supabase_client()`). This bypasses RLS intentionally because `user_id` comes from the verified JWT.
+- **RLS policies** are configured for defense-in-depth: users can only SELECT/INSERT/UPDATE/DELETE their own rows.
+- **Keys are stored as plaintext** in the database. Supabase encrypts data at rest. Application-level encryption can be added in a future iteration.
+
+## How to Add a New API-Key-Based Provider
+
+1. **Choose a provider name**: Use lowercase, no spaces (e.g. `'elevenlabs'`, `'vercel'`, `'supabase'`).
+2. **Frontend**: Add a settings UI field where the user pastes their key. Insert into `user_api_keys` with the chosen provider name.
+3. **Backend** (`services/tool_injector.py`): In the `inject_user_tools` pre-hook, add a block:
+   ```python
+   key = get_api_key(user_id, "your_provider")
+   if key:
+       tools.append(YourProviderTools(api_key=key))
+   ```
+   For providers that need extra metadata (e.g. Supabase project ref), use `get_api_key_with_metadata()`:
+   ```python
+   data = get_api_key_with_metadata(user_id, "supabase")
+   if data:
+       project_ref = (data.get("metadata") or {}).get("project_ref")
+       if project_ref:
+           pat = data["api_key"]
+           tools.append(MCPTools(
+               url=f"https://mcp.supabase.com/mcp?project_ref={project_ref}",
+               transport="streamable-http",
+               server_params=StreamableHTTPClientParams(
+                   url=f"https://mcp.supabase.com/mcp?project_ref={project_ref}",
+                   headers={"Authorization": f"Bearer {pat}"},
+               ),
+           ))
+   ```
+4. **No migration needed** — the `provider` column is free-text.
+
+## Environment Variables Required
+
+| Variable | Purpose |
+|----------|---------|
+| `SUPABASE_URL` | Supabase project API URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key for server-side DB access |
+
+No provider-specific env vars are needed — keys come from the database per-user.

--- a/email_followup.py
+++ b/email_followup.py
@@ -2,40 +2,10 @@
 
 from agno.agent import Agent
 from agno.models.google import Gemini
-from agno.tools.gmail import GmailTools
-from agno.tools.googlesheets import GoogleSheetsTools
 
-from services.oauth_store import get_google_credentials
+from services.tool_injector import inject_user_tools
 
 from db import db
-
-
-def inject_oauth_tools(agent: Agent, user_id: str) -> None:
-    """Pre-hook: fetch per-user Google credentials and inject tools before each run."""
-    print(f"[pre-hook] inject_oauth_tools called — user_id={user_id!r}")
-    if not user_id:
-        print("[pre-hook] No user_id, skipping tool injection")
-        return
-
-    tools = []
-    sheets_creds = get_google_credentials(user_id, "google_sheets")
-    if sheets_creds:
-        tools.append(
-            GoogleSheetsTools(
-                creds=sheets_creds,
-                enable_read_sheet=True,
-                enable_update_sheet=True,
-                enable_create_sheet=True,
-                enable_create_duplicate_sheet=False,
-            )
-        )
-
-    gmail_creds = get_google_credentials(user_id, "google_gmail")
-    if gmail_creds:
-        tools.append(GmailTools(creds=gmail_creds))
-
-    print(f"[pre-hook] Injecting {len(tools)} tool(s): {[type(t).__name__ for t in tools]}")
-    agent.set_tools(tools)
 
 
 # Setup Email Follow-Up Agent
@@ -110,7 +80,7 @@ email_followup_agent = Agent(
         "- Inform the user they need to connect their Google account in Settings",
         "- Explain that Google Sheets and Gmail access are required for this agent",
     ],
-    pre_hooks=[inject_oauth_tools],
+    pre_hooks=[inject_user_tools],
     db=db,
     update_memory_on_run=False,
     add_history_to_context=True,

--- a/gmail_sheets_agent.py
+++ b/gmail_sheets_agent.py
@@ -2,40 +2,10 @@
 
 from agno.agent import Agent
 from agno.models.google import Gemini
-from agno.tools.gmail import GmailTools
-from agno.tools.googlesheets import GoogleSheetsTools
 
-from services.oauth_store import get_google_credentials
+from services.tool_injector import inject_user_tools
 
 from db import db
-
-
-def inject_oauth_tools(agent: Agent, user_id: str) -> None:
-    """Pre-hook: fetch per-user Google credentials and inject tools before each run."""
-    print(f"[pre-hook] inject_oauth_tools called — user_id={user_id!r}")
-    if not user_id:
-        print("[pre-hook] No user_id, skipping tool injection")
-        return
-
-    tools = []
-    sheets_creds = get_google_credentials(user_id, "google_sheets")
-    if sheets_creds:
-        tools.append(
-            GoogleSheetsTools(
-                creds=sheets_creds,
-                enable_read_sheet=True,
-                enable_update_sheet=True,
-                enable_create_sheet=True,
-                enable_create_duplicate_sheet=False,
-            )
-        )
-
-    gmail_creds = get_google_credentials(user_id, "google_gmail")
-    if gmail_creds:
-        tools.append(GmailTools(creds=gmail_creds))
-
-    print(f"[pre-hook] Injecting {len(tools)} tool(s): {[type(t).__name__ for t in tools]}")
-    agent.set_tools(tools)
 
 
 # Setup Gmail & Google Sheets Agent
@@ -60,7 +30,7 @@ gmail_sheets_agent = Agent(
         "- Inform the user they need to connect their Google account in Settings",
         "- Explain that Google Sheets and Gmail access are required for this agent",
     ],
-    pre_hooks=[inject_oauth_tools],
+    pre_hooks=[inject_user_tools],
     db=db,
     update_memory_on_run=False,
     add_history_to_context=True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ google-api-python-client
 psycopg2-binary
 pgvector
 supabase
+elevenlabs

--- a/services/api_key_store.py
+++ b/services/api_key_store.py
@@ -1,0 +1,37 @@
+"""Per-user API key storage backed by Supabase."""
+
+from typing import Optional
+
+from services.oauth_store import get_supabase_client
+
+
+def get_api_key(user_id: str, provider: str) -> Optional[str]:
+    """Fetch a stored API key for the given user and provider, or None."""
+    result = (
+        get_supabase_client()
+        .table("user_api_keys")
+        .select("api_key")
+        .eq("user_id", user_id)
+        .eq("provider", provider)
+        .limit(1)
+        .execute()
+    )
+    if not result.data:
+        return None
+    return result.data[0]["api_key"]
+
+
+def get_api_key_with_metadata(user_id: str, provider: str) -> Optional[dict]:
+    """Return {"api_key": ..., "metadata": ...} or None."""
+    result = (
+        get_supabase_client()
+        .table("user_api_keys")
+        .select("api_key, metadata")
+        .eq("user_id", user_id)
+        .eq("provider", provider)
+        .limit(1)
+        .execute()
+    )
+    if not result.data:
+        return None
+    return result.data[0]

--- a/services/tool_injector.py
+++ b/services/tool_injector.py
@@ -1,0 +1,63 @@
+"""Shared pre-hook that injects per-user tools (OAuth + API keys + MCP) before each agent run."""
+
+from agno.agent import Agent
+from agno.tools.eleven_labs import ElevenLabsTools
+from agno.tools.gmail import GmailTools
+from agno.tools.googlesheets import GoogleSheetsTools
+from agno.tools.mcp import MCPTools
+from agno.tools.mcp.params import StreamableHTTPClientParams
+
+from services.api_key_store import get_api_key, get_api_key_with_metadata
+from services.oauth_store import get_google_credentials
+
+
+def inject_user_tools(agent: Agent, user_id: str) -> None:
+    """Pre-hook: fetch per-user credentials (OAuth + API keys) and inject tools before each run."""
+    print(f"[pre-hook] inject_user_tools called for {agent.name} — user_id={user_id!r}")
+    if not user_id:
+        print("[pre-hook] No user_id, skipping tool injection")
+        return
+
+    tools = []
+
+    # --- OAuth-based tools ---
+    sheets_creds = get_google_credentials(user_id, "google_sheets")
+    if sheets_creds:
+        tools.append(
+            GoogleSheetsTools(
+                creds=sheets_creds,
+                enable_read_sheet=True,
+                enable_update_sheet=True,
+                enable_create_sheet=True,
+                enable_create_duplicate_sheet=False,
+            )
+        )
+
+    gmail_creds = get_google_credentials(user_id, "google_gmail")
+    if gmail_creds:
+        tools.append(GmailTools(creds=gmail_creds))
+
+    # --- API-key-based tools ---
+    elevenlabs_key = get_api_key(user_id, "elevenlabs")
+    if elevenlabs_key:
+        tools.append(ElevenLabsTools(api_key=elevenlabs_key))
+
+    # --- Supabase MCP tools ---
+    supabase_data = get_api_key_with_metadata(user_id, "supabase")
+    if supabase_data:
+        project_ref = (supabase_data.get("metadata") or {}).get("project_ref")
+        if project_ref:
+            pat = supabase_data["api_key"]
+            tools.append(
+                MCPTools(
+                    url=f"https://mcp.supabase.com/mcp?project_ref={project_ref}",
+                    transport="streamable-http",
+                    server_params=StreamableHTTPClientParams(
+                        url=f"https://mcp.supabase.com/mcp?project_ref={project_ref}",
+                        headers={"Authorization": f"Bearer {pat}"},
+                    ),
+                )
+            )
+
+    print(f"[pre-hook] Injecting {len(tools)} tool(s): {[type(t).__name__ for t in tools]}")
+    agent.set_tools(tools)

--- a/supabase/migrations/20260210092913_create_user_api_keys.sql
+++ b/supabase/migrations/20260210092913_create_user_api_keys.sql
@@ -1,0 +1,35 @@
+create table public.user_api_keys (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    provider text not null,          -- 'elevenlabs', 'vercel', 'supabase', etc.
+    api_key text not null,
+    label text,                      -- optional friendly name
+    metadata jsonb default '{}',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint uq_user_api_keys_user_provider unique (user_id, provider)
+);
+
+-- Index for fast lookups
+create index idx_user_api_keys_user_provider
+    on public.user_api_keys (user_id, provider);
+
+-- Reuse existing updated_at trigger function from OAuth migration
+create trigger trg_user_api_keys_updated_at
+    before update on public.user_api_keys
+    for each row
+    execute function public.update_updated_at_column();
+
+-- RLS: users can only access their own rows
+alter table public.user_api_keys enable row level security;
+
+create policy "Users can view their own api keys"
+    on public.user_api_keys for select using (auth.uid() = user_id);
+create policy "Users can insert their own api keys"
+    on public.user_api_keys for insert with check (auth.uid() = user_id);
+create policy "Users can update their own api keys"
+    on public.user_api_keys for update using (auth.uid() = user_id);
+create policy "Users can delete their own api keys"
+    on public.user_api_keys for delete using (auth.uid() = user_id);
+
+grant select, insert, update, delete on public.user_api_keys to authenticated;

--- a/supabase_manager.py
+++ b/supabase_manager.py
@@ -1,0 +1,44 @@
+"""Supabase Manager Agent - Manages a user's Supabase project via MCP tools."""
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+
+from services.tool_injector import inject_user_tools
+
+from db import db
+
+
+supabase_manager_agent = Agent(
+    name="Supabase Manager",
+    model=Gemini(id="gemini-3-flash-preview"),
+    description="Manages a user's Supabase project — list tables, run queries, apply migrations, manage edge functions, and check security advisors.",
+    instructions=[
+        "You are a Supabase Manager that helps users manage their Supabase project using MCP tools.",
+        "",
+        "## Capabilities",
+        "- List and inspect database tables and schemas",
+        "- Execute SQL queries (SELECT, INSERT, UPDATE)",
+        "- Apply database migrations (CREATE TABLE, ALTER TABLE, etc.)",
+        "- List, view, and deploy Edge Functions",
+        "- Check security and performance advisors",
+        "- Generate TypeScript types from the database schema",
+        "",
+        "## Safety Rules",
+        "- ALWAYS ask for user confirmation before destructive operations (DROP, DELETE, TRUNCATE)",
+        "- ALWAYS ask for confirmation before applying migrations that alter or remove columns",
+        "- Show the SQL you plan to execute and wait for approval before running it",
+        "- Use apply_migration for DDL operations, execute_sql for DML queries",
+        "",
+        "## Missing Credentials",
+        "If Supabase tools are not available, inform the user:",
+        "'Please connect your Supabase account in Settings by adding your Personal Access Token and project reference.'",
+    ],
+    pre_hooks=[inject_user_tools],
+    db=db,
+    update_memory_on_run=False,
+    add_history_to_context=True,
+    add_datetime_to_context=True,
+    add_name_to_context=True,
+    markdown=True,
+    reasoning=False,
+)


### PR DESCRIPTION
## Summary

- Users can now connect tools that use API keys (ElevenLabs, Supabase) from their settings, and the platform automatically makes those tools available during conversations
- New **Supabase Manager** agent lets users manage their Supabase project (tables, queries, migrations, edge functions) directly through chat, using their Personal Access Token stored in Settings
- Consolidates duplicate `inject_oauth_tools` pre-hooks into a single shared `inject_user_tools` module that handles OAuth, API keys, and MCP tools

## What changed

### New files
- `services/api_key_store.py` — `get_api_key()` and `get_api_key_with_metadata()` backed by Supabase
- `services/tool_injector.py` — shared `inject_user_tools` pre-hook (OAuth + API keys + Supabase MCP)
- `supabase_manager.py` — Supabase Manager agent with safety guardrails for destructive operations
- `supabase/migrations/20260210092913_create_user_api_keys.sql` — `user_api_keys` table with RLS policies
- `docs/api-key-storage.md` — ADR explaining the design decisions

### Modified files
- `email_followup.py` — replaced inline `inject_oauth_tools` with shared `inject_user_tools`
- `gmail_sheets_agent.py` — same consolidation
- `agno_agent.py` — registered `supabase_manager_agent` in the agents list
- `requirements.txt` — added `elevenlabs` dependency

### Known pitfalls addressed
- MCPTools uses `transport="streamable-http"` + `url=` as top-level params to avoid stdio default bug
- `reload=False` already set in `agno_agent.py` (MCP connections break with reload)
- Migration reuses existing `update_updated_at_column()` trigger from OAuth migration

## Test plan
- [ ] Run migration on Supabase project
- [ ] Insert a test API key row for `elevenlabs` provider and verify ElevenLabs tools appear in agent run
- [ ] Insert a test row for `supabase` provider (with `metadata.project_ref`) and verify Supabase Manager agent connects via MCP
- [ ] Verify email_followup and gmail_sheets agents still receive OAuth tools correctly
- [ ] Confirm `reload=False` is set in the serve call

🤖 Generated with [Claude Code](https://claude.com/claude-code)