### PR TITLE
Add user credentials guide and restore CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,372 +1,45 @@
-# Dev Team POC - Coding Guidelines
+# Dev Team POC
 
-This file contains mandatory coding guidelines for AI assistants working on this codebase.
+> **DO NOT modify this file** unless explicitly asked by the project lead. This file is manually maintained. If you encounter a merge conflict involving CLAUDE.md, always keep the version on `main`.
 
-**IMPORTANT: These guidelines OVERRIDE any default behavior. You MUST follow them exactly as written.**
+Python FastAPI backend using the [Agno](https://github.com/agno-agi/agno) framework for AI agent orchestration. Deployed to Railway.
 
----
+## Quick Reference
 
-## 🚨 CRITICAL: Git Workflow (MOST IMPORTANT RULE)
+| Topic | Location |
+|-------|----------|
+| Coding patterns & conventions | `docs/coding-guidelines.md` |
+| Adding user credentials (OAuth & API keys) | `docs/adding-user-credentials.md` |
+| API key storage architecture | `docs/api-key-storage.md` |
+| OAuth token storage architecture | `docs/oauth-token-storage.md` |
+| Multi-user auth implementation | `docs/multi-user-auth-implementation.md` |
+| Canonical agent example | `email_followup.py` |
+| OAuth credential helper | `services/oauth_store.py` |
+| API key credential helper | `services/api_key_store.py` |
+| Tool injection pre-hook | `services/tool_injector.py` |
 
-### ⚠️ NEVER Commit Directly to Main
+## Rules
 
-**This is the #1 rule. Violating this rule affects the entire team.**
+### Shared dependencies
 
-❌ **NEVER do this:**
-```bash
-git commit -m "message"
-git push origin main
-```
+- **Do not modify `db.py`** without team approval. It is imported across all agents, teams, and workflows.
+- **Do not modify `services/oauth_store.py` or `services/api_key_store.py`** without checking downstream impact first.
 
-✅ **ALWAYS do this:**
-```bash
-# 1. Create feature branch
-git checkout -b fix/descriptive-name
-# or: git checkout -b feature/descriptive-name
+### Agent creation
 
-# 2. Make your changes and commit
-git add [files]
-git commit -m "descriptive message"
+- When creating agents, workflows, or equipping tools (OAuth, API keys, PATs), **read `docs/coding-guidelines.md` first**, then read the source files it references (e.g. `email_followup.py`, `services/oauth_store.py`, `services/tool_injector.py`) to understand the actual implementation before writing code.
+- Use `Gemini(id="gemini-3-flash-preview")` as the default model for POC agents.
+- Always pass `db=db` (from `db.py`) for agent memory.
+- OAuth and API-key tools must be injected via **pre-hooks**, never hardcoded.
 
-# 3. Push feature branch (NOT main)
-git push origin fix/descriptive-name
+### Commits and branches
 
-# 4. Create PR via GitHub
-# 5. Wait for review and approval
-# 6. Team merges PR
-```
+- Branch naming: `feature/<brief-desc>`, `fix/<brief-desc>`, `hotfix/<brief-desc>`
+- PR descriptions: focus on customer impact, not technical details. Write for non-technical readers.
+- **Never alter git history** (amend, rebase, force-push) on branches already pushed to remote. Always create new commits instead.
+- Merge PRs with `--squash --delete-branch` to keep main history clean and remove stale branches.
+- **Never push directly to main.** All changes must go through a PR.
 
-### Branch Naming Convention
+### Before creating new files
 
-| Type | Format | Example |
-|------|--------|---------|
-| Bug fix | `fix/short-description` | `fix/database-url-support` |
-| New feature | `feature/short-description` | `feature/email-followup-workflow` |
-| Hotfix | `hotfix/short-description` | `hotfix/oauth-credentials` |
-| Refactor | `refactor/short-description` | `refactor/agent-tools` |
-
-### Why This Matters
-
-- **Team review**: Every change needs review before going to production
-- **Railway deployment**: Main branch auto-deploys to production
-- **Rollback safety**: PRs provide clear history for reverting
-- **Discussion**: PRs allow team discussion before merge
-
-### If You Accidentally Commit to Main
-
-1. **DO NOT PUSH** - Stop immediately
-2. Create feature branch from current state: `git checkout -b fix/description`
-3. Reset main to remote: `git checkout main && git reset --hard origin/main`
-4. Push feature branch and create PR
-
-### If You Already Pushed to Main (Critical Error)
-
-1. Notify team immediately
-2. Consider reverting: `git revert [commit-hash]`
-3. Create proper PR with fixes
-4. Update this document if you violated a rule not documented here
-
----
-
-## 🚨 Critical: Shared Dependencies
-
-### Database (`db.py`)
-
-**Do not modify `db.py` unless necessary.** It is a shared dependency — changes affect the entire project. Discuss with the team first.
-
-**Current behavior:**
-- Supports `DATABASE_URL` (Railway/Vercel/Heroku standard)
-- Supports `SUPABASE_DB_URL` (legacy/explicit Supabase)
-- Fallback: constructs from `SUPABASE_PROJECT` + `SUPABASE_PASSWORD`
-- Exports `SUPABASE_DB_URL` for backward compatibility with `knowledge_base.py`
-
-**If you must modify:**
-1. Document the reason clearly
-2. Check all imports: `from db import ...`
-3. Ensure backward compatibility
-4. Test knowledge_base.py integration
-5. Get team approval before committing
-
----
-
-## 📋 Agent Creation Patterns
-
-### Standard Agent Structure
-
-All agents in this project follow this pattern:
-
-```python
-from agno.agent import Agent
-from agno.models.google import Gemini
-from db import db
-
-# Model selection
-MODEL = Gemini(id="gemini-3-flash-preview")  # Cost-effective for POC
-
-agent_name = Agent(
-    name="Agent Name",
-    model=MODEL,
-    description="Brief description of what this agent does",
-    instructions=[
-        "You do X",
-        "You handle Y",
-        "You format output as Z",
-        "Always provide clear status updates",
-    ],
-    tools=[...],  # or injected via pre_hooks
-    db=db,  # Shared database for memory
-)
-```
-
-### Key Principles
-
-1. **Use Gemini Flash for POC** - Cost: ~$0.19/M tokens vs ~$9/M for Claude Sonnet 4.5
-2. **Shared database** - Always use `db` from `db.py` for agent memory
-3. **Clear instructions** - Each agent should have 5-10 specific instruction bullets
-4. **Descriptive names** - Agent names should clearly indicate their role
-
----
-
-## 🔐 OAuth Integration Pattern
-
-### Pre-Hook Pattern (MANDATORY)
-
-For agents that need Google OAuth tools (Sheets, Gmail, Docs), follow the `email_followup.py` pattern:
-
-```python
-from agno.agent import Agent
-from agno.tools.googlesheets import GoogleSheetsTools
-from agno.tools.gmail import GmailTools
-from utils.credentials import get_google_credentials
-from db import db
-
-def inject_oauth_tools(agent: Agent, user_id: str) -> None:
-    """Pre-hook: Fetch per-user Google credentials and inject tools before each run.
-
-    This pattern ensures:
-    - Each user gets their own OAuth credentials
-    - Tools are only added if credentials exist
-    - Agent can be used by multiple users with their own Google accounts
-    """
-    tools = []
-
-    # Google Sheets
-    sheets_creds = get_google_credentials(user_id, "google_sheets")
-    if sheets_creds:
-        tools.append(GoogleSheetsTools(
-            creds=sheets_creds,
-            # ... additional config
-        ))
-
-    # Gmail
-    gmail_creds = get_google_credentials(user_id, "google_gmail")
-    if gmail_creds:
-        tools.append(GmailTools(creds=gmail_creds))
-
-    agent.set_tools(tools)
-
-# Agent with OAuth
-my_agent = Agent(
-    name="My Agent",
-    model=MODEL,
-    description="Agent that uses Google APIs",
-    instructions=[...],
-    tools=[],  # Empty - tools injected via pre_hook
-    pre_hooks=[inject_oauth_tools],  # ⚠️ CRITICAL: This injects OAuth tools
-    db=db,
-)
-```
-
-### Why Pre-Hooks?
-
-- **Per-user credentials**: Each user authenticates with their own Google account
-- **Lazy loading**: Only load credentials when agent actually runs
-- **Security**: Credentials never hardcoded, always fetched at runtime
-- **Multi-tenancy**: Same agent can serve multiple users
-
-### DO NOT:
-
-❌ **Create custom Google Sheets tools** - Use `GoogleSheetsTools` from Agno
-❌ **Hardcode credentials** - Always use `get_google_credentials()`
-❌ **Return mock/dummy data** - If OAuth fails, report the error clearly
-❌ **Skip pre_hooks** - OAuth tools MUST be injected via pre_hooks
-
-### Reference Files:
-
-- **Canonical OAuth pattern**: `email_followup.py`
-- **Workflow example**: `workflows/email_followup_workflow_working.py`
-- **Working agents**: `lead_reader_agent`, `results_logger_agent`, `campaign_coordinator_agent` in `agents/calling_agents.py`
-
----
-
-## 🔧 Workflow Patterns
-
-### Multi-Step Workflows
-
-Break complex workflows into clear steps with explicit boundaries:
-
-```python
-from agno.workflow import Workflow, Step
-
-my_workflow = Workflow(
-    name="Workflow Name",
-    description="Overall workflow purpose",
-    steps=[
-        Step(
-            name="Step 1: Action",
-            agent=my_agent,
-            description="""
-            **STEP 1 of N: Phase Name**
-
-            Your specific tasks for THIS step only:
-            1. Do X
-            2. Do Y
-            3. STOP here - don't proceed to next step
-
-            **IMPORTANT:**
-            - End with: "Step 1 complete. Ready for Step 2."
-            """,
-        ),
-        # ... more steps
-    ],
-)
-```
-
-### Step Principles
-
-1. **Explicit boundaries** - Each step clearly states what it does and where it stops
-2. **User communication** - Steps should communicate progress frequently
-3. **No step bleed** - Step 1 should never do Step 2's work
-4. **Stop markers** - Always end with clear completion message
-
----
-
-## 🚀 Deployment
-
-### Railway Environment
-
-- **Production testing**: We test in Railway production, not local
-- **Environment variables**: Railway auto-provides `DATABASE_URL`
-- **No local dev**: Changes are deployed and tested in production
-
-### Required Environment Variables
-
-| Variable | Purpose | Required? |
-|----------|---------|-----------|
-| `DATABASE_URL` | Railway/Vercel/Heroku standard DB URL | ✅ (Railway auto-provides) |
-| `SUPABASE_DB_URL` | Legacy explicit Supabase URL | Optional (fallback) |
-| `SUPABASE_PROJECT` | Supabase project ID | Optional (fallback) |
-| `SUPABASE_PASSWORD` | Supabase password | Optional (fallback) |
-| `GOOGLE_CLIENT_ID` | OAuth credentials | ✅ (for OAuth workflows) |
-| `GOOGLE_CLIENT_SECRET` | OAuth credentials | ✅ (for OAuth workflows) |
-
----
-
-## 📝 Commit and PR Workflow
-
-### Every Change Goes Through a PR
-
-**Remember: Main branch is protected. Every change needs a PR.**
-
-1. **Create feature branch** (see Git Workflow section above)
-2. **Make commits on feature branch**
-3. **Push feature branch to remote**
-4. **Create PR on GitHub**
-5. **Wait for review and approval**
-6. **Team merges PR**
-
-### Commit Message Format
-
-Follow conventional commits format:
-
-```
-Type: Brief description
-
-Optional longer description
-- Bullet points for details
-- What changed and why
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
-```
-
-**Types:**
-- `Fix:` - Bug fixes
-- `Feature:` - New features
-- `Refactor:` - Code restructuring
-- `Docs:` - Documentation only
-- `Test:` - Test additions/fixes
-
-**Examples:**
-- `Fix: Add DATABASE_URL support for Railway deployment`
-- `Feature: Add OAuth integration to calling agents`
-- `Refactor: Consolidate agent tools into pre_hook pattern`
-
-### Commit Best Practices
-
-1. **Minimal changes** - Only change what's necessary
-2. **Single concern** - One logical change per commit
-3. **Test before commit** - Verify locally if possible
-4. **Descriptive messages** - Explain what and why
-
----
-
-## ⚠️ Common Pitfalls
-
-### 1. Mock Data
-
-❌ **WRONG**: Return hardcoded mock data (John Smith, Sarah Lee, etc.)
-✅ **CORRECT**: Use real OAuth tools to fetch actual data
-
-### 2. Hanging Workflows
-
-❌ **WRONG**: Expect specific inputs immediately without asking
-✅ **CORRECT**: Add conversational handling to ask for required inputs
-
-### 3. Database Modifications
-
-❌ **WRONG**: Modify `db.py` without checking team guidelines
-✅ **CORRECT**: Check this file first, discuss with team if modification needed
-
-### 4. Tool Selection
-
-❌ **WRONG**: Create custom tools when Agno provides them
-✅ **CORRECT**: Use `GoogleSheetsTools`, `GmailTools` from `agno.tools.google`
-
----
-
-## 📚 Reference Files
-
-### Patterns to Follow
-
-- **OAuth Integration**: `email_followup.py`
-- **Workflow Structure**: `workflows/email_followup_workflow_working.py`
-- **Agent Creation**: `agents/calling_agents.py`
-- **Database Setup**: `db.py` (read-only reference)
-
-### Patterns to Avoid
-
-- **Mock Data**: `tools/google_sheets_tools.py` (deprecated, don't use)
-
----
-
-## 🤝 Team Collaboration
-
-### Before Modifying Shared Code
-
-1. Read this CLAUDE.md file
-2. Check if the file is listed as a shared dependency
-3. Understand current behavior and why it exists
-4. Consider impact on other components
-5. Discuss with team if uncertain
-
-### When in Doubt
-
-**ASK before:**
-- Modifying `db.py`
-- Changing OAuth patterns
-- Refactoring working code
-- Adding new dependencies
-
----
-
-*Last updated: 2026-02-10*
+Always explore the repo file tree first. Place files in the existing structure rather than creating new directories.

--- a/docs/adding-user-credentials.md
+++ b/docs/adding-user-credentials.md
@@ -1,0 +1,155 @@
+# Adding OAuth or API Key Credentials for a User
+
+This guide explains how to store per-user credentials so agents can use tools (Google Sheets, Gmail, Supabase, ElevenLabs, etc.) on behalf of a specific user.
+
+## Which Table to Use
+
+| Credential type | Table | When to use |
+|-----------------|-------|-------------|
+| OAuth (access + refresh tokens) | `user_oauth_connections` | Provider requires an OAuth flow (Google, Slack, Notion) |
+| API key / PAT (single secret) | `user_api_keys` | User pastes a key from the provider's dashboard |
+
+## Adding an OAuth Connection
+
+Insert a row into `user_oauth_connections` with the user's tokens from the OAuth flow.
+
+### Example: Google Sheets
+
+```sql
+INSERT INTO public.user_oauth_connections (
+    user_id,
+    provider,
+    provider_account_id,
+    account_label,
+    access_token,
+    refresh_token,
+    token_uri,
+    scopes
+) VALUES (
+    'b9d59094-51a4-48a3-8c0d-fc0870e6f6f9',   -- user's auth.users UUID
+    'google_sheets',                             -- provider key (must match oauth_provider enum)
+    'gianfranco@omnigpt.co',                     -- provider account identifier (e.g. email)
+    'Google Sheets',                             -- friendly label for UI
+    'ya29.a0AUM...',                             -- access token from OAuth flow
+    '1//05GZ4qA...',                             -- refresh token from OAuth flow
+    'https://oauth2.googleapis.com/token',       -- Google's token endpoint
+    ARRAY[
+        'https://www.googleapis.com/auth/spreadsheets',
+        'https://www.googleapis.com/auth/drive.file',
+        'https://www.googleapis.com/auth/drive.readonly'
+    ]
+);
+```
+
+### Example: Gmail
+
+```sql
+INSERT INTO public.user_oauth_connections (
+    user_id,
+    provider,
+    provider_account_id,
+    account_label,
+    access_token,
+    refresh_token,
+    token_uri,
+    scopes
+) VALUES (
+    'b9d59094-51a4-48a3-8c0d-fc0870e6f6f9',
+    'google_gmail',
+    'gianfranco@omnigpt.co',
+    'Gmail',
+    'ya29.a0AUM...',
+    '1//05hTPBG...',
+    'https://oauth2.googleapis.com/token',
+    ARRAY[
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.modify',
+        'https://www.googleapis.com/auth/calendar.events',
+        'https://www.googleapis.com/auth/calendar.readonly',
+        'https://www.googleapis.com/auth/calendar.freebusy',
+        'https://www.googleapis.com/auth/calendar.calendarlist.readonly'
+    ]
+);
+```
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `user_id` | UUID from `auth.users` — the Supabase Auth user |
+| `provider` | Must be a valid `oauth_provider` enum value. Adding a new provider requires a migration (`ALTER TYPE oauth_provider ADD VALUE 'new_provider'`) |
+| `provider_account_id` | Unique identifier from the provider (e.g. email). Allows one user to connect multiple accounts for the same provider |
+| `access_token` | Token from the OAuth flow |
+| `refresh_token` | Refresh token for automatic renewal |
+| `token_uri` | Provider's token endpoint (Google: `https://oauth2.googleapis.com/token`) |
+| `scopes` | Array of granted OAuth scopes |
+
+### How It Gets Used
+
+`services/oauth_store.py` → `get_google_credentials(user_id, provider)` fetches the row and returns a `google.oauth2.credentials.Credentials` object. The `inject_user_tools` pre-hook in `services/tool_injector.py` calls this and wraps the credentials in the appropriate Agno tool class (`GoogleSheetsTools`, `GmailTools`).
+
+## Adding an API Key
+
+Insert a row into `user_api_keys` with the user's key.
+
+### Example: Supabase PAT (with metadata)
+
+```sql
+INSERT INTO public.user_api_keys (
+    user_id,
+    provider,
+    api_key,
+    metadata
+) VALUES (
+    'b9d59094-51a4-48a3-8c0d-fc0870e6f6f9',
+    'supabase',
+    'sbp_14c0db...',                              -- Supabase Personal Access Token
+    '{"project_ref": "qmfsbntaygggtjzlemyg"}'::jsonb  -- extra config needed by the tool
+);
+```
+
+### Example: ElevenLabs (simple key, no metadata)
+
+```sql
+INSERT INTO public.user_api_keys (
+    user_id,
+    provider,
+    api_key
+) VALUES (
+    'b9d59094-51a4-48a3-8c0d-fc0870e6f6f9',
+    'elevenlabs',
+    'sk_abc123...'
+);
+```
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `user_id` | UUID from `auth.users` |
+| `provider` | Free-text string (e.g. `'elevenlabs'`, `'supabase'`, `'vercel'`). No migration needed for new providers |
+| `api_key` | The secret key or PAT |
+| `label` | Optional friendly name for UI display |
+| `metadata` | Optional JSONB for provider-specific config (e.g. `project_ref` for Supabase) |
+
+### How It Gets Used
+
+`services/api_key_store.py` → `get_api_key(user_id, provider)` returns the key string. For providers that need metadata, use `get_api_key_with_metadata(user_id, provider)` which returns `{"api_key": ..., "metadata": ...}`. The `inject_user_tools` pre-hook handles both patterns.
+
+## Adding Support for a New Provider
+
+### New OAuth provider
+
+1. Create a migration: `ALTER TYPE public.oauth_provider ADD VALUE 'new_provider';`
+2. Add a credentials builder in `services/oauth_store.py` if the provider isn't Google-based.
+3. Add the tool to `inject_user_tools` in `services/tool_injector.py`.
+
+### New API key provider
+
+1. No migration needed — `provider` is free-text.
+2. Add a block in `inject_user_tools` in `services/tool_injector.py`:
+   ```python
+   key = get_api_key(user_id, "new_provider")
+   if key:
+       tools.append(NewProviderTools(api_key=key))
+   ```


### PR DESCRIPTION
## Summary

- New guide: `docs/adding-user-credentials.md` — step-by-step SQL examples for adding OAuth connections and API keys per user, using real production data as reference
- Restores CLAUDE.md to the concise version (was accidentally overwritten by a merge conflict resolution)
- Adds a do-not-modify warning to CLAUDE.md to prevent future accidental overwrites