### PR TITLE
Switch content team image gen to Nano Banana Pro

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ OPENROUTER_API_KEY='sk-or-v1-xxxxx'
 # Get yours from: https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=your-elevenlabs-api-key-here
 
+# Google AI API Key (required for Nano Banana Pro image generation in Content Team)
+# Get yours from: https://aistudio.google.com/apikey
+GOOGLE_API_KEY=your-google-api-key-here
+
 # Google OAuth Credentials (required for Gmail + Google Sheets integration)
 # Get these from: https://console.cloud.google.com/apis/credentials
 # Built-in token generator available at: http://localhost:8000/google-auth

--- a/content_creation.py
+++ b/content_creation.py
@@ -3,7 +3,12 @@
 from agno.agent import Agent
 from agno.models.google import Gemini
 from agno.team import Team
-from agno.tools.openai import OpenAITools
+from agno.tools import nano_banana as _nb
+from agno.tools.nano_banana import NanoBananaTools
+
+# Allow Nano Banana Pro (gemini-3-pro-image-preview) until Agno adds it upstream
+if "gemini-3-pro-image-preview" not in _nb.ALLOWED_MODELS:
+    _nb.ALLOWED_MODELS.append("gemini-3-pro-image-preview")
 
 from db import db
 
@@ -87,9 +92,9 @@ content_writer = Agent(
 # image_generator = Agent(
 #     name="Image Generator",
 #     model=Gemini(id="gemini-3-flash-preview"),
-#     description="Generates images using OpenAI's image generation and manages visual assets for content. Creates high-quality images to enhance content.",
+#     description="Generates images using Google's Nano Banana Pro model and manages visual assets for content. Creates high-quality images to enhance content.",
 #     instructions=[
-#         "You are an Image Generator who creates visual assets using OpenAI's image generation.",
+#         "You are an Image Generator who creates visual assets using Google's Nano Banana Pro image generation.",
 #         "",
 #         "## CRITICAL: Always Use Image Generation Tool",
 #         "When asked to generate, create, or make an image, you MUST:",
@@ -104,7 +109,7 @@ content_writer = Agent(
 #         "Return generated images in markdown format.",
 #         "Suggest appropriate visual placements within the content.",
 #     ],
-#     tools=[OpenAITools(image_model="gpt-image-1")],
+#     tools=[NanoBananaTools(model="gemini-3-pro-image-preview")],
 #     db=db,
 #     # enable_session_summaries=True,
 #     update_memory_on_run=False,
@@ -131,7 +136,7 @@ content_creation_team = Team(
     model=Gemini(id="gemini-3-flash-preview"),
     db=db,
     members=[content_strategist, content_writer],
-    tools=[OpenAITools(image_model="gpt-image-1")],
+    tools=[NanoBananaTools(model="gemini-3-pro-image-preview")],
     instructions=[
         "You are the leader of a Content Creation Team.",
         "",
@@ -194,7 +199,7 @@ content_creation_team = Team(
         "The ONLY exception is PHASE 3, where you generate exploratory sample images for style selection.",
         "",
         "## Image Generation",
-        "You have direct access to image generation tools via generate_image.",
+        "You have direct access to image generation tools via create_image.",
         "- Include returned image URLs in markdown format: ![description](url)",
         "- ALWAYS prepend the style template to every image prompt after PHASE 4",
         "- Generate an image for EVERY content piece — never leave text placeholders",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ agno
 mcp
 anthropic
 google-genai
+Pillow
 openai
 uvicorn[standard]
 fastapi


### PR DESCRIPTION
## Summary
- Content team now uses Google's Nano Banana Pro for image generation instead of OpenAI, delivering better text rendering, character consistency across carousel slides, and stronger complex prompt handling
- Adds `GOOGLE_API_KEY` to `.env.example` and `Pillow` to dependencies

## Test plan
- [ ] Set `GOOGLE_API_KEY` env var and verify content team can generate images via `create_image`
- [ ] Verify style template workflow produces visually consistent images across multiple slides
- [ ] Confirm video generation is not exposed as a tool option

🤖 Generated with [Claude Code](https://claude.com/claude-code)