### PR TITLE
Fix Gemini API error after image generation

### DIFF
--- a/content_creation.py
+++ b/content_creation.py
@@ -137,6 +137,7 @@ content_creation_team = Team(
     db=db,
     members=[content_strategist, content_writer],
     tools=[NanoBananaTools(model="gemini-3-pro-image-preview")],
+    send_media_to_model=False,
     instructions=[
         "You are the leader of a Content Creation Team.",
         "",


### PR DESCRIPTION
## Summary
- Fixes the Gemini API error "Please ensure that function call turn comes immediately after a user turn or after a function response turn" that occurred on follow-up messages after the content team generates images
- Adds `send_media_to_model=False` to prevent Agno from sending generated image data back to Gemini, which doesn't support receiving media in its message history

## Test plan
- [ ] Generate images with the content team and verify they generate successfully
- [ ] Send a follow-up message (e.g. "approved!") and confirm no API error occurs
- [ ] Verify the multi-phase content workflow completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)