### PR TITLE
Fix deploy failure: unpin yanked google-genai version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 agno
 mcp
 anthropic
-google-genai==1.0.1  # Pin to version compatible with Agno 2.4.8
+google-genai
 Pillow
 openai
 uvicorn[standard]


### PR DESCRIPTION
## Summary
- Fixes deploy failure caused by `google-genai==1.0.1` being yanked from PyPI
- Unpins the version so pip resolves to the latest compatible release

## Test plan
- [ ] Verify deploy succeeds on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)