### PR TITLE
Fix: Add context limit to campaign_coordinator_agent (1M+ token overf…

### DIFF
--- a/agents/calling_agents.py
+++ b/agents/calling_agents.py
@@ -215,7 +215,8 @@ campaign_coordinator_agent = Agent(
     ],  # Google Sheets tools injected via pre_hook
     pre_hooks=[make_tool_hook("google_sheets")],
     db=db,
-    add_history_to_context=True,
+    add_history_to_context=True,  # Orchestrator needs context for conversation
+    num_history_messages=10,  # FIX: Limit history to prevent 1M+ token overflow
     add_datetime_to_context=True,
     markdown=True,
 )


### PR DESCRIPTION
…low)

Problem:
- campaign_coordinator_agent had add_history_to_context=True with NO limit
- This caused context to accumulate to 1M+ tokens during campaigns
- Error: "input token count exceeds maximum allowed 1048576"

Root Cause:
- While workflow agents (lead_reader, calling_coordinator, results_logger) were fixed with add_history_to_context=False in PR #97
- The standalone campaign_coordinator_agent was MISSED
- It's exposed in AgentOS and can be used directly
- No num_history_messages limit caused unlimited accumulation

Solution:
- Add num_history_messages=10 limit to campaign_coordinator_agent
- Same limit as campaign_manager (main orchestrator)
- Keeps conversational context while preventing overflow

This completes the context overflow fix series:
- PR #97: Fixed workflow step agents
- This PR: Fixed standalone coordinator agent