### PR TITLE
Feature: Create custom ElevenLabs batch calling toolkit

### DIFF
--- a/agents/calling_agents.py
+++ b/agents/calling_agents.py
@@ -5,16 +5,12 @@ Agents for managing the outbound calling workflow via ElevenLabs.
 These agents coordinate to read leads, make calls, retry failures, and log results.
 
 Uses OAuth-based Google Sheets access (like email_followup agent).
+Uses custom ElevenLabsBatchCallingTools toolkit for API access.
 """
 
 from agno.agent import Agent
 from agno.models.google import Gemini
-from tools.elevenlabs_tools import (
-    submit_batch_call,
-    get_batch_status,
-    retry_failed_calls,
-    get_call_result
-)
+from tools.elevenlabs_batch_calling import ElevenLabsBatchCallingTools
 from services.tool_injector import make_tool_hook
 from db import db
 
@@ -87,12 +83,7 @@ calling_coordinator_agent = Agent(
         "Always report: total calls, successful, failed, pending retry",
         "Keep the user informed of progress throughout the campaign"
     ],
-    tools=[
-        submit_batch_call,
-        get_batch_status,
-        retry_failed_calls,
-        get_call_result
-    ],
+    tools=[ElevenLabsBatchCallingTools()],  # Use custom toolkit for batch calling
     db=db,
     add_history_to_context=False,  # FIX: Disable history to prevent context overflow in workflows
     num_history_messages=5,  # FIX: Limit to last 5 messages as safety measure
@@ -208,11 +199,8 @@ campaign_coordinator_agent = Agent(
         "",
         "You are friendly, professional, and results-oriented"
     ],
-    tools=[
-        submit_batch_call,
-        get_batch_status,
-        retry_failed_calls
-    ],  # Google Sheets tools injected via pre_hook
+    tools=[ElevenLabsBatchCallingTools()],  # Use custom toolkit for batch calling
+    # Google Sheets tools injected via pre_hook
     pre_hooks=[make_tool_hook("google_sheets")],
     db=db,
     add_history_to_context=True,  # Orchestrator needs context for conversation

--- a/tools/elevenlabs_batch_calling.py
+++ b/tools/elevenlabs_batch_calling.py
@@ -1,0 +1,226 @@
+"""
+ElevenLabs Batch Calling Toolkit
+
+Custom Agno toolkit for ElevenLabs Conversational AI batch calling.
+Uses REST API directly to avoid SDK version compatibility issues.
+"""
+
+import os
+from typing import List, Dict, Any, Optional
+import requests
+from agno.tools import Toolkit
+
+
+class ElevenLabsBatchCallingTools(Toolkit):
+    """Toolkit for ElevenLabs Conversational AI batch calling operations.
+
+    This toolkit uses the ElevenLabs REST API directly instead of the Python SDK
+    to avoid version compatibility issues with the rapidly changing SDK.
+
+    Required environment variables:
+    - ELEVENLABS_API_KEY: Your ElevenLabs API key
+    - ELEVENLABS_AGENT_ID: Your conversational AI agent ID
+    - ELEVENLABS_PHONE_NUMBER_ID: Your ElevenLabs phone number ID
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        phone_number_id: Optional[str] = None,
+        base_url: str = "https://api.elevenlabs.io/v1",
+    ):
+        """Initialize the ElevenLabs batch calling toolkit.
+
+        Args:
+            api_key: ElevenLabs API key (defaults to ELEVENLABS_API_KEY env var)
+            agent_id: Conversational AI agent ID (defaults to ELEVENLABS_AGENT_ID env var)
+            phone_number_id: Phone number ID (defaults to ELEVENLABS_PHONE_NUMBER_ID env var)
+            base_url: Base URL for ElevenLabs API
+        """
+        super().__init__(name="elevenlabs_batch_calling")
+
+        self.api_key = api_key or os.getenv("ELEVENLABS_API_KEY")
+        self.agent_id = agent_id or os.getenv("ELEVENLABS_AGENT_ID")
+        self.phone_number_id = phone_number_id or os.getenv("ELEVENLABS_PHONE_NUMBER_ID")
+        self.base_url = base_url
+
+        # Register all methods as tools
+        self.register(self.submit_batch_call)
+        self.register(self.get_batch_status)
+        self.register(self.retry_failed_calls)
+        self.register(self.get_call_result)
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers for API requests."""
+        if not self.api_key:
+            raise ValueError("ELEVENLABS_API_KEY not set")
+        return {
+            "xi-api-key": self.api_key,
+            "Content-Type": "application/json"
+        }
+
+    def submit_batch_call(self, campaign_name: str, recipients: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Submit a batch of outbound calls to ElevenLabs.
+
+        Each recipient should be a dict with:
+        - phone_number (required): The phone number to call in E.164 format
+        - restaurant_name (optional): Name for personalization
+        - city (optional): City for personalization
+        - Any other custom fields your ElevenLabs agent uses
+
+        Args:
+            campaign_name: A name for this batch (e.g. "US Restaurants Feb 2026")
+            recipients: List of dicts with phone_number and custom fields
+
+        Returns:
+            Dict with batch_id to track this job
+
+        Example:
+            recipients = [
+                {"phone_number": "+1234567890", "restaurant_name": "Joe's Pizza", "city": "NYC"},
+                {"phone_number": "+1987654321", "restaurant_name": "Pasta House", "city": "LA"}
+            ]
+            result = toolkit.submit_batch_call("US Restaurants", recipients)
+        """
+        if not self.agent_id or not self.phone_number_id:
+            return {
+                "error": "Missing configuration",
+                "message": "Set ELEVENLABS_AGENT_ID and ELEVENLABS_PHONE_NUMBER_ID env vars"
+            }
+
+        try:
+            url = f"{self.base_url}/convai/batch-calling/submit"
+            payload = {
+                "call_name": campaign_name,
+                "agent_id": self.agent_id,
+                "agent_phone_number_id": self.phone_number_id,
+                "recipients": recipients
+            }
+
+            response = requests.post(url, headers=self._get_headers(), json=payload, timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            return {
+                "success": True,
+                "batch_id": data.get("id"),
+                "status": "submitted",
+                "total_recipients": len(recipients),
+                "message": f"Batch call submitted successfully with {len(recipients)} recipients"
+            }
+
+        except requests.exceptions.RequestException as e:
+            return {
+                "error": "Failed to submit batch call",
+                "message": str(e),
+                "status_code": getattr(e.response, "status_code", None) if hasattr(e, "response") else None
+            }
+
+    def get_batch_status(self, batch_id: str) -> Dict[str, Any]:
+        """Check the current status of a batch calling job.
+
+        Args:
+            batch_id: The batch ID returned from submit_batch_call
+
+        Returns:
+            Status info including how many calls completed, failed, etc.
+
+        Example:
+            status = toolkit.get_batch_status("batch_abc123")
+            print(f"Completed: {status['completed']}/{status['total']}")
+        """
+        try:
+            url = f"{self.base_url}/convai/batch-calling/{batch_id}"
+            response = requests.get(url, headers=self._get_headers(), timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            return {
+                "success": True,
+                "batch_id": batch_id,
+                "status": data.get("status"),
+                "total": data.get("total", 0),
+                "completed": data.get("completed", 0),
+                "failed": data.get("failed", 0),
+                "in_progress": data.get("total", 0) - data.get("completed", 0) - data.get("failed", 0)
+            }
+
+        except requests.exceptions.RequestException as e:
+            return {
+                "error": "Failed to get batch status",
+                "message": str(e),
+                "status_code": getattr(e.response, "status_code", None) if hasattr(e, "response") else None
+            }
+
+    def retry_failed_calls(self, batch_id: str) -> Dict[str, Any]:
+        """Retry all failed/unanswered calls in a batch.
+
+        Use this when get_batch_status shows failed calls.
+        ElevenLabs will retry all unsuccessful calls.
+
+        Args:
+            batch_id: The batch to retry
+
+        Returns:
+            Confirmation of the retry
+
+        Example:
+            result = toolkit.retry_failed_calls("batch_abc123")
+            if result['success']:
+                print("Retry submitted!")
+        """
+        try:
+            url = f"{self.base_url}/convai/batch-calling/{batch_id}/retry"
+            response = requests.post(url, headers=self._get_headers(), timeout=30)
+            response.raise_for_status()
+
+            return {
+                "success": True,
+                "batch_id": batch_id,
+                "retry_status": "submitted",
+                "message": "Failed calls queued for retry"
+            }
+
+        except requests.exceptions.RequestException as e:
+            return {
+                "error": "Failed to retry calls",
+                "message": str(e),
+                "status_code": getattr(e.response, "status_code", None) if hasattr(e, "response") else None
+            }
+
+    def get_call_result(self, conversation_id: str) -> Dict[str, Any]:
+        """Get the transcript and outcome of a specific call.
+
+        Args:
+            conversation_id: The ID of the individual call/conversation
+
+        Returns:
+            Transcript, duration, evaluation, and data collected
+
+        Example:
+            result = toolkit.get_call_result("conv_abc123")
+            print(f"Transcript: {result['transcript']}")
+            print(f"Duration: {result['duration']} seconds")
+        """
+        try:
+            url = f"{self.base_url}/convai/conversations/{conversation_id}"
+            response = requests.get(url, headers=self._get_headers(), timeout=30)
+            response.raise_for_status()
+
+            data = response.json()
+            return {
+                "success": True,
+                "conversation_id": conversation_id,
+                "transcript": data.get("transcript"),
+                "duration": data.get("duration"),
+                "evaluation": data.get("evaluation"),
+                "data_collected": data.get("data_collection")
+            }
+
+        except requests.exceptions.RequestException as e:
+            return {
+                "error": "Failed to get call result",
+                "message": str(e),
+                "status_code": getattr(e.response, "status_code", None) if hasattr(e, "response") else None
+            }


### PR DESCRIPTION
Problem:
- ElevenLabs Python SDK has rapidly changing API structure
- Methods like .convai vs .conversational_ai keep changing
- Method names like .submit() don't exist on BatchCallsClient
- SDK documentation is incomplete for batch calling

Solution:
Create custom Agno toolkit that uses REST API directly:
- ElevenLabsBatchCallingTools(Toolkit) class
- Uses requests library to call ElevenLabs REST API
- Avoids SDK version compatibility issues
- Follows Agno toolkit patterns (like GoogleSheetsTools)

Implementation:
1. New file: tools/elevenlabs_batch_calling.py
   - ElevenLabsBatchCallingTools class
   - Four methods: submit_batch_call, get_batch_status, retry_failed_calls, get_call_result
   - Uses REST API: https://api.elevenlabs.io/v1/convai/batch-calling/*
   - Proper error handling with status codes

2. Updated: agents/calling_agents.py
   - Replace individual @tool functions with toolkit
   - calling_coordinator_agent now uses ElevenLabsBatchCallingTools()
   - campaign_coordinator_agent now uses ElevenLabsBatchCallingTools()

Benefits:
- ✅ No SDK version issues
- ✅ Stable REST API endpoints
- ✅ Better organized as Agno toolkit
- ✅ Can be injected like other toolkits
- ✅ Easier to maintain and test

API Endpoints Used:
- POST /v1/convai/batch-calling/submit
- GET /v1/convai/batch-calling/{batch_id}
- POST /v1/convai/batch-calling/{batch_id}/retry
- GET /v1/convai/conversations/{conversation_id}