### PR TITLE
Fix: Re-enable send_media_to_model for content team

### DIFF
--- a/content_creation.py
+++ b/content_creation.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from agno.agent import Agent
 from agno.media import Image
+from agno.models.anthropic import Claude
 from agno.models.google import Gemini
 from agno.team import Team
 from agno.tools import nano_banana as _nb
@@ -246,11 +247,11 @@ content_creation_team = Team(
     id="content-creation-team",
     name="Content Creation Team",
     description="A team that creates content including articles, blog posts, and other written materials with AI-generated images.",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Claude(id="claude-sonnet-4-5-20250929"),
     db=db,
     members=[content_strategist, content_writer],
     tools=[DynamicNanoBananaTools(model="gemini-3-pro-image-preview")],
-    send_media_to_model=False,
+    send_media_to_model=True,
     instructions=[
         "You are the leader of a Content Creation Team.",
         "",


### PR DESCRIPTION
## Summary
- Switches the content team leader model from Gemini to Claude, which correctly handles media in conversation history
- Re-enables `send_media_to_model=True` so the team can analyze generated images again
- Fixes the Gemini "function call turn ordering" error that broke the second turn after image generation

## Test plan
- [ ] Generate an image with the content team
- [ ] Send a follow-up message (e.g. "approved!") — verify no API error on the second turn
- [ ] Verify the team leader can see and reference generated images in its responses