### PR TITLE
Fix: Remove knowledge base search from existing project workflow

### DIFF
--- a/workflows/product_requirements_workflow.py
+++ b/workflows/product_requirements_workflow.py
@@ -399,10 +399,9 @@ def create_summary_executor(step_input: StepInput) -> StepOutput:
 # ============================================================================
 
 def get_project_context_executor(step_input: StepInput) -> StepOutput:
-    """Step 1 (Existing): Get project from DB and search knowledge base."""
+    """Step 1 (Existing): Get project from DB."""
     import re
     from tools.project_tools import get_project
-    from utils.knowledge_base import get_knowledge_base
 
     # Extract project_id from input
     project_id_match = re.search(r'PROJECT_ID:\s*(.+)', str(step_input.input), re.IGNORECASE)
@@ -425,29 +424,12 @@ def get_project_context_executor(step_input: StepInput) -> StepOutput:
 
     _log("📂", "GET-PROJECT", f"Found project: {project['project_name']}")
 
-    # Search knowledge base for context
-    kb = get_knowledge_base()
-    context_parts = [f"Project: {project['project_name']}"]
-
-    try:
-        # Search for project documents in knowledge base
-        results = kb.search(query=f"project {project['project_name']}", limit=3)
-        if results:
-            _log("🔍", "KNOWLEDGE-BASE", f"Found {len(results)} KB entries")
-            context_parts.append("\nKnowledge Base Context:")
-            for r in results:
-                context_parts.append(f"- {r.content[:200]}...")
-        else:
-            _log("⚠️", "KNOWLEDGE-BASE", "No KB entries found")
-
-            # Fallback: Mention PRD and Architecture docs if available
-            if project.get('prd_doc_url'):
-                context_parts.append(f"\nPRD URL: {project['prd_doc_url']}")
-            if project.get('architecture_doc_url'):
-                context_parts.append(f"\nArchitecture URL: {project['architecture_doc_url']}")
-
-    except Exception as e:
-        _log("⚠️", "KNOWLEDGE-BASE", f"KB search failed: {e}")
+    # Build context from project DB record
+    context_parts = []
+    if project.get('prd_doc_url'):
+        context_parts.append(f"PRD URL: {project['prd_doc_url']}")
+    if project.get('architecture_doc_url'):
+        context_parts.append(f"Architecture URL: {project['architecture_doc_url']}")
 
     # Build context output
     output = f"""
@@ -457,7 +439,6 @@ Project Name: {project['project_name']}
 Description: {project.get('project_description', 'N/A')}
 Status: {project.get('status', 'unknown')}
 GitHub Repo: {project.get('github_repo_url', 'Not set')}
-
 {chr(10).join(context_parts)}
 """
 


### PR DESCRIPTION
KB search was failing with 'unexpected keyword argument limit'. Removed it from get_project_context_executor — project DB record provides sufficient context (PRD URL, architecture URL, etc.).