### PR TITLE
Hotfix: Kimi K2.5 direct + fix invalid Team params (crash fix)

### DIFF
--- a/agents/hr_jd_writer.py
+++ b/agents/hr_jd_writer.py
@@ -1,13 +1,13 @@
 """HR JD Writer Agent — writes bilingual job descriptions (English + Thai)."""
 
 from agno.agent import Agent
-from agno.models.google import Gemini
+from agno.models.moonshot import MoonShot
 
 from db import db
 
 hr_jd_writer_agent = Agent(
     name="HR JD Writer Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=MoonShot(id="kimi-k2.5"),
     description="You are a professional HR copywriter who specializes in bilingual (English and Thai) job descriptions for the Thai market.",
     instructions=[
         "You are an expert HR copywriter for the Thai job market.",

--- a/agents/hr_job_poster.py
+++ b/agents/hr_job_poster.py
@@ -1,14 +1,14 @@
 """HR Job Poster Agent — posts job listings to Indeed."""
 
 from agno.agent import Agent
-from agno.models.google import Gemini
+from agno.models.moonshot import MoonShot
 
 from services.tool_injector import make_tool_hook
 from db import db
 
 hr_job_poster_agent = Agent(
     name="HR Job Poster Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=MoonShot(id="kimi-k2.5"),
     description="You are an HR operations specialist who posts job listings to Indeed Thailand and LinkedIn Jobs via XML feeds.",
     instructions=[
         "You are an HR Job Poster Agent. Your job is to add job listings to the job feed.",

--- a/agents/hr_lead.py
+++ b/agents/hr_lead.py
@@ -1,13 +1,13 @@
 """HR Lead Agent — gathers hiring requirements from the user."""
 
 from agno.agent import Agent
-from agno.models.google import Gemini
+from agno.models.moonshot import MoonShot
 
 from db import db
 
 hr_lead_agent = Agent(
     name="HR Lead Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=MoonShot(id="kimi-k2.5"),
     description="You are an HR Lead who gathers all necessary information to create a job posting for a company in Thailand.",
     instructions=[
         "You are an HR Lead Agent for companies hiring in Thailand.",

--- a/teams/hr_team.py
+++ b/teams/hr_team.py
@@ -1,7 +1,7 @@
 """HR Team — orchestrates job description creation and posting to Indeed Thailand."""
 
 from agno.team import Team
-from agno.models.openrouter import OpenRouter
+from agno.models.moonshot import MoonShot
 
 from agents.hr_lead import hr_lead_agent
 from agents.hr_jd_writer import hr_jd_writer_agent
@@ -10,8 +10,7 @@ from db import db
 
 hr_team = Team(
     name="HR Team",
-    model=OpenRouter(id="google/gemini-3-flash-preview", max_tokens=8192),
-    mode="coordinate",
+    model=MoonShot(id="kimi-k2.5"),
     db=db,
     members=[
         hr_lead_agent,
@@ -73,7 +72,6 @@ Help companies post jobs to Indeed Thailand by:
 - Keep the conversation natural and professional
 """,
     ],
-    success_criteria="Job posted to Indeed Thailand with a live URL returned to the user.",
     markdown=True,
     show_members_responses=True,
     add_history_to_context=True,


### PR DESCRIPTION
## Summary

Production is down — fixes startup crash caused by invalid Team constructor params.

- **Fix crash**: Remove `success_criteria` and `mode="coordinate"` from `hr_team` (not valid in agno 2.4.8 — causes `TypeError: Team.__init__() got unexpected keyword argument 'success_criteria'`)
- **Kimi direct**: All HR agents now use `MoonShot(id="kimi-k2.5")` via Moonshot API (`MOONSHOT_API_KEY` already set in Railway)

## Test plan

- [ ] Deploy and confirm server starts (no 502)
- [ ] Verify `/indeed-feed.xml` returns 200 at production URL
- [ ] Test HR Team responds in OmniGPT UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)