### PR TITLE
Fix: Indeed browser stealth mode + better login error diagnostics

### DIFF
--- a/tools/browser_posting_tools.py
+++ b/tools/browser_posting_tools.py
@@ -13,11 +13,20 @@ Requires Playwright + Chromium (installed via Dockerfile).
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 from typing import Optional
 
 from agno.tools import Toolkit
+
+# Stealth JS injected into every page to remove automation fingerprints
+_STEALTH_JS = """
+Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3] });
+Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+window.chrome = { runtime: {} };
+"""
 
 
 class IndeedBrowserPosterTools(Toolkit):
@@ -38,7 +47,7 @@ class IndeedBrowserPosterTools(Toolkit):
         """Check if Indeed credentials are configured and login works.
 
         Returns:
-            JSON with login status.
+            JSON with login status and any debug info.
         """
         if not self.email or not self.password:
             return json.dumps({
@@ -63,10 +72,9 @@ class IndeedBrowserPosterTools(Toolkit):
         Args:
             title: Job title (e.g. "Padel Coach")
             description: Full job description — plain text, 200-5000 chars.
-                         The HTML version is not needed — Indeed handles formatting.
             location: Location string (e.g. "Bangkok, Thailand")
             apply_email: Email address where candidates apply
-            company: Company name (usually auto-filled from Indeed account)
+            company: Company name (auto-filled from Indeed account)
             job_type: FULL_TIME, PART_TIME, CONTRACT, INTERNSHIP
             salary_min: Minimum monthly salary in THB (optional)
             salary_max: Maximum monthly salary in THB (optional)
@@ -78,7 +86,6 @@ class IndeedBrowserPosterTools(Toolkit):
             return json.dumps({
                 "success": False,
                 "error": "INDEED_EMAIL and INDEED_PASSWORD must be set in Railway env vars.",
-                "fix": "Ask admin to run: railway variables set INDEED_EMAIL=... INDEED_PASSWORD=...",
             })
 
         return asyncio.run(self._post_job_async(
@@ -89,6 +96,33 @@ class IndeedBrowserPosterTools(Toolkit):
     # Async implementation
     # ------------------------------------------------------------------
 
+    async def _new_stealth_context(self, playwright):
+        """Launch Chromium with anti-bot stealth settings."""
+        browser = await playwright.chromium.launch(
+            headless=True,
+            args=[
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-gpu",
+                "--disable-blink-features=AutomationControlled",
+                "--window-size=1280,800",
+                "--disable-infobars",
+            ],
+        )
+        context = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/121.0.0.0 Safari/537.36"
+            ),
+            viewport={"width": 1280, "height": 800},
+            locale="en-US",
+            timezone_id="Asia/Bangkok",
+            java_script_enabled=True,
+        )
+        await context.add_init_script(_STEALTH_JS)
+        return browser, context
+
     async def _check_login_async(self) -> str:
         try:
             from playwright.async_api import async_playwright
@@ -96,23 +130,20 @@ class IndeedBrowserPosterTools(Toolkit):
             return json.dumps({"success": False, "error": "playwright not installed"})
 
         async with async_playwright() as p:
-            browser = await p.chromium.launch(
-                headless=True,
-                args=["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-            )
-            context = await browser.new_context(
-                user_agent=(
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/120.0.0.0 Safari/537.36"
-                ),
-            )
+            browser, context = await self._new_stealth_context(p)
             page = await context.new_page()
             try:
-                await _indeed_login(page, self.email, self.password)
-                return json.dumps({"success": True, "message": "Login successful."})
+                result = await _indeed_login(page, self.email, self.password)
+                return json.dumps({"success": True, "message": "Login successful.", "url": page.url})
             except Exception as e:
-                return json.dumps({"success": False, "error": str(e)})
+                screenshot_b64 = await _screenshot_b64(page)
+                return json.dumps({
+                    "success": False,
+                    "error": str(e),
+                    "page_url": page.url,
+                    "page_title": await page.title(),
+                    "debug_screenshot_b64": screenshot_b64[:200] + "..." if screenshot_b64 else None,
+                })
             finally:
                 await browser.close()
 
@@ -136,59 +167,52 @@ class IndeedBrowserPosterTools(Toolkit):
             })
 
         async with async_playwright() as p:
-            browser = await p.chromium.launch(
-                headless=True,
-                args=["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-            )
-            context = await browser.new_context(
-                user_agent=(
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/120.0.0.0 Safari/537.36"
-                ),
-                locale="en-US",
-            )
+            browser, context = await self._new_stealth_context(p)
             page = await context.new_page()
             try:
                 # Step 1: Login
                 await _indeed_login(page, self.email, self.password)
 
-                # Step 2: Go to post job page
+                # Step 2: Navigate to post job
                 await page.goto(
                     "https://employers.indeed.com/jobs/post",
                     wait_until="domcontentloaded",
                     timeout=20000,
                 )
+                await page.wait_for_timeout(2000)
 
                 # Step 3: Job Title
                 title_input = await _wait_for_any(page, [
-                    'input[id="jobTitle"]',
                     'input[name="jobTitle"]',
+                    'input[id="jobTitle"]',
                     'input[placeholder*="title" i]',
                     'input[aria-label*="title" i]',
+                    'input[type="text"]',
                 ], timeout=15000)
                 if not title_input:
-                    raise Exception("Could not find job title input. Indeed UI may have changed.")
+                    page_info = f"URL: {page.url} | Title: {await page.title()}"
+                    raise Exception(f"Job title input not found. Page: {page_info}")
                 await title_input.fill(title)
                 await _click_continue(page)
+                await page.wait_for_timeout(1500)
 
-                # Step 4: Location (may be pre-filled or combined with title step)
+                # Step 4: Location
                 try:
                     loc_input = await _wait_for_any(page, [
-                        'input[id="location"]',
                         'input[name="location"]',
+                        'input[id="location"]',
                         'input[placeholder*="location" i]',
                         'input[aria-label*="location" i]',
-                    ], timeout=8000)
+                    ], timeout=6000)
                     if loc_input:
-                        await loc_input.fill("")
+                        await loc_input.triple_click()
                         await loc_input.fill(location)
-                        await page.wait_for_timeout(1000)  # let autocomplete load
-                        # Press Enter to accept first suggestion or just continue
+                        await page.wait_for_timeout(1000)
                         await page.keyboard.press("Escape")
                         await _click_continue(page)
+                        await page.wait_for_timeout(1500)
                 except Exception:
-                    pass  # Location might be on same step as description
+                    pass
 
                 # Step 5: Job type
                 try:
@@ -201,31 +225,35 @@ class IndeedBrowserPosterTools(Toolkit):
                     jtype_label = jtype_map.get(job_type, "Full-time")
                     jtype_option = await _wait_for_any(page, [
                         f'label:has-text("{jtype_label}")',
-                        f'[data-testid*="jobType"]',
                         f'input[value="{job_type}"]',
+                        f'input[value="{jtype_label}"]',
                     ], timeout=5000)
                     if jtype_option:
                         await jtype_option.click()
                         await _click_continue(page)
+                        await page.wait_for_timeout(1500)
                 except Exception:
-                    pass  # Job type might be optional or on different step
+                    pass
 
-                # Step 6: Description
+                # Step 6: Description — contenteditable div (Indeed uses rich text editor)
                 desc_input = await _wait_for_any(page, [
                     'div[contenteditable="true"]',
-                    'textarea[id="jobDescription"]',
                     'textarea[name="description"]',
+                    'textarea[id="jobDescription"]',
                     '[data-testid="jobDescriptionInput"]',
+                    '[role="textbox"]',
                 ], timeout=15000)
                 if desc_input:
                     await desc_input.click()
-                    # Clear existing content and type description
                     await page.keyboard.press("Control+A")
                     await page.keyboard.press("Delete")
-                    await desc_input.fill(description) if await desc_input.get_attribute("contenteditable") is None else None
-                    if await desc_input.get_attribute("contenteditable"):
-                        await page.keyboard.type(description)
+                    content_editable = await desc_input.get_attribute("contenteditable")
+                    if content_editable:
+                        await page.keyboard.type(description, delay=5)
+                    else:
+                        await desc_input.fill(description)
                     await _click_continue(page)
+                    await page.wait_for_timeout(1500)
 
                 # Step 7: Salary (optional)
                 if salary_min or salary_max:
@@ -234,40 +262,52 @@ class IndeedBrowserPosterTools(Toolkit):
                             'input[name="salaryMin"]',
                             'input[id="salaryMin"]',
                             'input[placeholder*="minimum" i]',
+                            'input[placeholder*="min" i]',
                         ], timeout=5000)
                         max_input = await _wait_for_any(page, [
                             'input[name="salaryMax"]',
                             'input[id="salaryMax"]',
                             'input[placeholder*="maximum" i]',
+                            'input[placeholder*="max" i]',
                         ], timeout=3000)
                         if min_input and salary_min:
                             await min_input.fill(str(salary_min))
                         if max_input and salary_max:
                             await max_input.fill(str(salary_max))
                         await _click_continue(page)
+                        await page.wait_for_timeout(1500)
                     except Exception:
-                        pass  # Salary is optional
+                        pass
 
                 # Step 8: Apply options (email)
                 try:
+                    email_option = await _wait_for_any(page, [
+                        'label:has-text("email" i)',
+                        'input[value="email"]',
+                        '[data-testid*="email"]',
+                    ], timeout=5000)
+                    if email_option:
+                        await email_option.click()
+
                     email_input = await _wait_for_any(page, [
                         'input[name="applyEmail"]',
+                        'input[name="applicationEmail"]',
                         'input[type="email"]',
                         'input[placeholder*="email" i]',
-                        'input[aria-label*"email" i]',
-                    ], timeout=8000)
+                    ], timeout=5000)
                     if email_input:
                         await email_input.fill(apply_email)
                         await _click_continue(page)
+                        await page.wait_for_timeout(1500)
                 except Exception:
                     pass
 
-                # Step 9: Review & Post — click the final Post/Submit button
+                # Step 9: Review & Post — find final Post button
                 posted = False
-                for btn_text in ["Post job", "Post Job", "Submit", "Publish"]:
+                for btn_text in ["Post job", "Post Job", "Post now", "Publish", "Submit"]:
                     try:
-                        btn = page.get_by_role("button", name=btn_text)
-                        if await btn.is_visible(timeout=5000):
+                        btn = page.get_by_role("button", name=btn_text, exact=False)
+                        if await btn.is_visible(timeout=4000):
                             await btn.click()
                             posted = True
                             break
@@ -275,7 +315,6 @@ class IndeedBrowserPosterTools(Toolkit):
                         continue
 
                 if not posted:
-                    # Try any button with "post" in it
                     try:
                         await page.click('button:has-text("Post")', timeout=5000)
                         posted = True
@@ -285,27 +324,28 @@ class IndeedBrowserPosterTools(Toolkit):
                 if not posted:
                     return json.dumps({
                         "success": False,
-                        "error": "Could not find the final Post button. Job form was filled but not submitted.",
+                        "error": "Could not find the Post button. Form may have been filled — check employers.indeed.com for a draft.",
                         "partial": True,
-                        "note": "Indeed UI may have changed. The job details were filled in — check employers.indeed.com for a draft.",
+                        "current_url": page.url,
                     })
 
-                # Wait for confirmation
                 await page.wait_for_timeout(3000)
-                final_url = page.url
-
                 return json.dumps({
                     "success": True,
                     "message": f"Job '{title}' posted to Indeed Thailand.",
-                    "url": final_url,
-                    "note": "Job may take a few hours to appear in search results.",
+                    "url": page.url,
+                    "note": "Job will appear in search results within a few hours.",
                 })
 
             except Exception as e:
+                page_url = page.url if page else "unknown"
+                page_title = await page.title() if page else "unknown"
                 return json.dumps({
                     "success": False,
                     "error": str(e),
-                    "tip": "Check INDEED_EMAIL / INDEED_PASSWORD in Railway env vars.",
+                    "page_url": page_url,
+                    "page_title": page_title,
+                    "tip": "If page_title shows CAPTCHA or Access Denied, Indeed is blocking the cloud server IP.",
                 })
             finally:
                 await browser.close()
@@ -316,44 +356,72 @@ class IndeedBrowserPosterTools(Toolkit):
 # ------------------------------------------------------------------
 
 async def _indeed_login(page, email: str, password: str) -> None:
-    """Log in to Indeed employer portal."""
-    from playwright.async_api import Page
+    """Log in to Indeed employer portal with stealth browser."""
     await page.goto(
         "https://secure.indeed.com/auth?hl=en&co=TH&continue=https%3A%2F%2Femployers.indeed.com%2F",
         wait_until="domcontentloaded",
         timeout=20000,
     )
-    # Step 1: email
+    await page.wait_for_timeout(2000)
+
+    page_title = await page.title()
+    page_url = page.url
+
+    # Step 1: email — confirmed selector from page inspection
     email_input = await _wait_for_any(page, [
         'input[name="__email"]',
         'input[type="email"]',
-        'input[id="input-email-address"]',
         'input[placeholder*="email" i]',
-    ], timeout=15000)
-    if not email_input:
-        raise Exception("Could not find email input on Indeed login page.")
-    await email_input.fill(email)
-    await _click_continue(page)
+        'input[aria-label*="email" i]',
+    ], timeout=12000)
 
-    # Step 2: password
-    await page.wait_for_timeout(1500)
+    if not email_input:
+        raise Exception(
+            f"Email input not found. Page: '{page_title}' at {page_url}. "
+            "Indeed may be showing a CAPTCHA or bot-detection page on this server IP."
+        )
+
+    await email_input.fill(email)
+    await page.wait_for_timeout(500)
+
+    # Click Continue (confirmed: button[type="submit"] with text "Continue")
+    await page.click('button[type="submit"]')
+    await page.wait_for_timeout(2000)
+
+    # Step 2: password — confirmed: input[type="password"] (no name/id)
     pwd_input = await _wait_for_any(page, [
-        'input[name="__password"]',
         'input[type="password"]',
-        'input[id="input-password"]',
+        'input[name="__password"]',
+        'input[name="password"]',
     ], timeout=10000)
+
     if not pwd_input:
-        raise Exception("Could not find password input. Check if 2FA is required or login failed.")
+        page_title = await page.title()
+        raise Exception(
+            f"Password input not found after email submission. "
+            f"Page: '{page_title}' at {page.url}. "
+            "Check if email is correct or if 2FA appeared."
+        )
+
     await pwd_input.fill(password)
-    await _click_continue(page)
+    await page.wait_for_timeout(500)
+    await page.click('button[type="submit"]')
 
     # Wait for employer dashboard
-    await page.wait_for_url("**/employers.indeed.com/**", timeout=15000)
+    try:
+        await page.wait_for_url("**/employers.indeed.com/**", timeout=15000)
+    except Exception:
+        page_title = await page.title()
+        raise Exception(
+            f"Login did not redirect to employer dashboard. "
+            f"Page: '{page_title}' at {page.url}. "
+            "Credentials may be wrong or additional verification required."
+        )
 
 
 async def _wait_for_any(page, selectors: list[str], timeout: int = 8000):
-    """Try each selector and return the first one found, or None."""
-    per = timeout // len(selectors)
+    """Try each selector and return the first visible one, or None."""
+    per = max(timeout // len(selectors), 1500)
     for sel in selectors:
         try:
             el = page.locator(sel).first
@@ -365,19 +433,27 @@ async def _wait_for_any(page, selectors: list[str], timeout: int = 8000):
 
 
 async def _click_continue(page) -> None:
-    """Click the Continue / Next / Submit button on the current step."""
-    for btn_text in ["Continue", "Next", "Submit", "Save and continue"]:
+    """Click the Continue / Next button on the current step."""
+    for btn_text in ["Continue", "Next", "Save and continue", "Save & continue"]:
         try:
-            btn = page.get_by_role("button", name=btn_text)
-            if await btn.is_visible(timeout=3000):
+            btn = page.get_by_role("button", name=btn_text, exact=False)
+            if await btn.is_visible(timeout=2000):
                 await btn.click()
-                await page.wait_for_timeout(1500)
+                await page.wait_for_timeout(1000)
                 return
         except Exception:
             continue
-    # Fallback: any submit button
     try:
-        await page.click('button[type="submit"]', timeout=3000)
-        await page.wait_for_timeout(1500)
+        await page.click('button[type="submit"]', timeout=2000)
+        await page.wait_for_timeout(1000)
     except Exception:
         pass
+
+
+async def _screenshot_b64(page) -> str:
+    """Take a screenshot and return as base64 string."""
+    try:
+        data = await page.screenshot(type="png")
+        return base64.b64encode(data).decode()
+    except Exception:
+        return ""


### PR DESCRIPTION
## Summary

Improves Indeed browser automation to bypass bot detection on cloud server IPs.

- Add `--disable-blink-features=AutomationControlled` Chrome flag
- Inject stealth JS to remove `navigator.webdriver` fingerprint
- Set Bangkok timezone + en-US locale for realistic browser profile
- Confirmed exact selectors from live page inspection (no more guessing):
  - Email: `input[name="__email"]` / `input[type="email"]`
  - Password: `input[type="password"]`
  - Submit: `button[type="submit"]`
- Better error messages now include `page_url` + `page_title` so we can see exactly what page Indeed returned (CAPTCHA, block page, or login form)

## If it still fails after this

If `page_title` in the error contains "Access Denied" or "Attention Required" (Cloudflare), the Railway IP is being blocked and we'd need a proxy solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)