### PR TITLE
Revert unnecessary db.py changes from PR #86

### DIFF
--- a/db.py
+++ b/db.py
@@ -2,33 +2,18 @@
 
 Shared database setup for all agents, teams, and workflows.
 Uses the same pattern as agent_os/main.py.
-
-Environment Variable Priority:
-1. DATABASE_URL - Railway/Vercel/Heroku standard (highest priority)
-2. SUPABASE_DB_URL - Explicit Supabase connection string
-3. SUPABASE_PROJECT + SUPABASE_PASSWORD - Construct connection string
 """
 
 from os import getenv
 
 from agno.db.postgres import PostgresDb
 
-# Priority 1: Check for Railway/Vercel/Heroku standard DATABASE_URL
-DATABASE_URL = getenv("DATABASE_URL")
-
-# Priority 2: Check for explicit SUPABASE_DB_URL
-if not DATABASE_URL:
-    DATABASE_URL = getenv("SUPABASE_DB_URL")
-
-# Priority 3: Construct from SUPABASE_PROJECT + SUPABASE_PASSWORD
-if not DATABASE_URL:
+# Get Supabase credentials from environment
+SUPABASE_DB_URL = getenv("SUPABASE_DB_URL")
+if not SUPABASE_DB_URL:
     SUPABASE_PROJECT = getenv("SUPABASE_PROJECT")
     SUPABASE_PASSWORD = getenv("SUPABASE_PASSWORD")
-    if SUPABASE_PROJECT and SUPABASE_PASSWORD:
-        DATABASE_URL = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}:5432/postgres"
+    SUPABASE_DB_URL = f"postgresql://postgres:{SUPABASE_PASSWORD}@db.{SUPABASE_PROJECT}:5432/postgres"
 
-# Setup PostgreSQL database
-db = PostgresDb(db_url=DATABASE_URL)
-
-# Export SUPABASE_DB_URL for backward compatibility with knowledge_base.py
-SUPABASE_DB_URL = DATABASE_URL
+# Setup Supabase PostgreSQL database
+db = PostgresDb(db_url=SUPABASE_DB_URL)


### PR DESCRIPTION
## Summary

Reverts the DATABASE_URL priority chain added in PR #86. Railway uses SUPABASE_DB_URL directly — the extra indirection was unused and added unnecessary complexity to a protected file.

## Test plan

- [ ] Verify SUPABASE_DB_URL is set on Railway
- [ ] Deploy and confirm agents connect to database normally