### PR TITLE
Fix: HR team kimi-k2.5 thinking error causing crashes and slowness

### DIFF
--- a/agents/hr_jd_writer.py
+++ b/agents/hr_jd_writer.py
@@ -7,7 +7,7 @@ from db import db
 
 hr_jd_writer_agent = Agent(
     name="HR JD Writer Agent",
-    model=MoonShot(id="kimi-k2.5"),
+    model=MoonShot(id="moonshot-v1-128k"),
     description="You are a professional HR copywriter who specializes in bilingual (English and Thai) job descriptions for the Thai market.",
     instructions=[
         "You are an expert HR copywriter for the Thai job market.",

--- a/agents/hr_job_poster.py
+++ b/agents/hr_job_poster.py
@@ -8,7 +8,7 @@ from db import db
 
 hr_job_poster_agent = Agent(
     name="HR Job Poster Agent",
-    model=MoonShot(id="kimi-k2.5"),
+    model=MoonShot(id="moonshot-v1-128k"),
     description="You are an HR operations specialist who posts job listings to any job board on the web.",
     instructions=[
         "You are an HR Job Poster Agent. You post job listings to any job board platform — configured or new.",

--- a/agents/hr_lead.py
+++ b/agents/hr_lead.py
@@ -7,7 +7,7 @@ from db import db
 
 hr_lead_agent = Agent(
     name="HR Lead Agent",
-    model=MoonShot(id="kimi-k2.5"),
+    model=MoonShot(id="moonshot-v1-128k"),
     description="You are an HR Lead who gathers all necessary information to create a job posting for a company in Thailand.",
     instructions=[
         "You are an HR Lead Agent for companies hiring in Thailand.",

--- a/teams/hr_team.py
+++ b/teams/hr_team.py
@@ -10,7 +10,7 @@ from db import db
 
 hr_team = Team(
     name="HR Team",
-    model=MoonShot(id="kimi-k2.5"),
+    model=MoonShot(id="moonshot-v1-128k"),
     db=db,
     members=[
         hr_lead_agent,


### PR DESCRIPTION
## Summary
- Reverts all HR agents and team from `kimi-k2.5` back to `moonshot-v1-128k`
- Fixes crash: _"thinking is enabled but reasoning_content is missing at index 2"_
- Fixes significant slowness in JD writing (thinking model adds chain-of-thought on every call)

## Root Cause
`kimi-k2.5` is a **reasoning model** with thinking enabled by default. Agno requires `reasoning_content` in all assistant messages when thinking is detected, but tool call messages don't include it — causing a validation crash during team delegation.

## Files Changed
- `agents/hr_lead.py`
- `agents/hr_jd_writer.py`
- `agents/hr_job_poster.py`
- `teams/hr_team.py`

## Test Plan
- [ ] Start HR team and request a JD — should complete without the thinking error
- [ ] JD writing should be noticeably faster than before
- [ ] Job posting flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)