### PR TITLE
Feature: HR team kimi-k2.5 (thinking disabled) + real Agno workflow

### DIFF
--- a/agents/hr_jd_writer.py
+++ b/agents/hr_jd_writer.py
@@ -7,7 +7,7 @@ from db import db
 
 hr_jd_writer_agent = Agent(
     name="HR JD Writer Agent",
-    model=MoonShot(id="moonshot-v1-128k"),
+    model=MoonShot(id="kimi-k2.5", extra_body={"thinking": {"type": "disabled"}}),
     description="You are a professional HR copywriter who specializes in bilingual (English and Thai) job descriptions for the Thai market.",
     instructions=[
         "You are an expert HR copywriter for the Thai job market.",

--- a/agents/hr_job_poster.py
+++ b/agents/hr_job_poster.py
@@ -8,7 +8,7 @@ from db import db
 
 hr_job_poster_agent = Agent(
     name="HR Job Poster Agent",
-    model=MoonShot(id="moonshot-v1-128k"),
+    model=MoonShot(id="kimi-k2.5", extra_body={"thinking": {"type": "disabled"}}),
     description="You are an HR operations specialist who posts job listings to any job board on the web.",
     instructions=[
         "You are an HR Job Poster Agent. You post job listings to any job board platform — configured or new.",
@@ -56,6 +56,12 @@ hr_job_poster_agent = Agent(
         "- Default job_type is FULL_TIME if not specified",
         "- apply_email is required — ask user if not provided",
         "- Always call close_session() when you are done with the browser",
+        "",
+        "## GRACEFUL DEGRADATION",
+        "- Browser tools (navigate_to, screenshot, etc.) may not always be available.",
+        "  If they are missing, tell the user that browser-based posting is not configured",
+        "  and offer to use a configured job board API instead.",
+        "- Always check which tools you actually have before attempting to use them.",
     ],
     pre_hooks=[
         make_tool_hook("job_boards"),

--- a/agents/hr_lead.py
+++ b/agents/hr_lead.py
@@ -7,7 +7,7 @@ from db import db
 
 hr_lead_agent = Agent(
     name="HR Lead Agent",
-    model=MoonShot(id="moonshot-v1-128k"),
+    model=MoonShot(id="kimi-k2.5", extra_body={"thinking": {"type": "disabled"}}),
     description="You are an HR Lead who gathers all necessary information to create a job posting for a company in Thailand.",
     instructions=[
         "You are an HR Lead Agent for companies hiring in Thailand.",

--- a/agno_agent.py
+++ b/agno_agent.py
@@ -38,6 +38,7 @@ from agents.calling_agents import (
 from campaign_manager import campaign_manager  # Pattern 1: Single Agent + Workflow
 from agno_pai.factory import factory_agent  # Agno PAI Factory (meta-agent)
 from teams.hr_team import hr_team  # HR Team (internal agents not exposed standalone)
+from workflows.hr_workflow import hr_workflow  # HR Hiring Pipeline (3-step workflow)
 from instagram_agent import instagram_agent  # Instagram Agent (OAuth-enabled)
 
 # Initialize Agent OS with Enhanced Tracing
@@ -89,6 +90,7 @@ agent_os = AgentOS(
         outbound_calling_workflow,  # Outbound Calling Campaign (full with ElevenLabs)
         simple_calling_workflow,  # Outbound Calling Campaign (simple test version)
         outbound_calling_test_workflow,  # Outbound Calling Test (OAuth, first iteration)
+        hr_workflow,  # HR Hiring Pipeline (3-step: gather requirements, write JD, post job)
     ],
     tracing=True,  # Enable built-in OpenTelemetry tracing
 )

--- a/services/tool_providers.py
+++ b/services/tool_providers.py
@@ -242,7 +242,14 @@ def _smart_browser(user_id: str):
     api_key = os.getenv("BROWSERBASE_API_KEY", "")
     project_id = os.getenv("BROWSERBASE_PROJECT_ID", "")
     if not api_key or not project_id:
-        print(f"[tool_providers] BROWSERBASE_API_KEY or BROWSERBASE_PROJECT_ID not set — smart_browser disabled")
+        missing = []
+        if not api_key:
+            missing.append("BROWSERBASE_API_KEY")
+        if not project_id:
+            missing.append("BROWSERBASE_PROJECT_ID")
+        print(f"[tool_providers] smart_browser disabled — missing env var(s): {', '.join(missing)}. "
+              f"Set these in Railway to enable managed browser for job posting. "
+              f"The agent will still work using configured job board APIs.")
         return None
     from tools.browserbase_tools import BrowserbaseInteractiveTools
     print(f"[tool_providers] BrowserbaseInteractiveTools for user {user_id!r}")

--- a/teams/hr_team.py
+++ b/teams/hr_team.py
@@ -10,7 +10,7 @@ from db import db
 
 hr_team = Team(
     name="HR Team",
-    model=MoonShot(id="moonshot-v1-128k"),
+    model=MoonShot(id="kimi-k2.5", extra_body={"thinking": {"type": "disabled"}}),
     db=db,
     members=[
         hr_lead_agent,

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -1,9 +1,10 @@
 """
 Workflows Module
 
-Only 2 workflows:
+Workflows:
 - product_requirements_workflow: Creates PRD or Feature Spec + Google Doc
 - software_development_workflow: Implementation only (takes Google Docs URL as input)
+- hr_workflow: 3-step HR hiring pipeline (gather requirements, write JD, post job)
 """
 
 from workflows.product_requirements_workflow import (
@@ -13,9 +14,11 @@ from workflows.product_requirements_workflow import (
 from workflows.software_development_workflow import (
     software_development_workflow,
 )
+from workflows.hr_workflow import hr_workflow
 
 __all__ = [
     "product_requirements_workflow",
     "run_product_requirements",
     "software_development_workflow",
+    "hr_workflow",
 ]

--- a/workflows/hr_workflow.py
+++ b/workflows/hr_workflow.py
@@ -1,0 +1,177 @@
+"""
+HR Hiring Workflow — Deterministic 3-step pipeline for job posting.
+
+Breaks the HR hiring process into 3 sequential steps:
+1. Gather Requirements — HR Lead collects all job details from the user
+2. Write Job Description — JD Writer produces bilingual JD (EN + Thai + HTML)
+3. Post the Job — Job Poster publishes to the selected platform
+
+Uses Agno Workflow + Step for deterministic execution (not Team delegation).
+"""
+
+from agno.workflow import Workflow, Step
+
+from agents.hr_lead import hr_lead_agent
+from agents.hr_jd_writer import hr_jd_writer_agent
+from agents.hr_job_poster import hr_job_poster_agent
+
+hr_workflow = Workflow(
+    name="HR Hiring Pipeline",
+    description="""
+    Guided hiring workflow for companies in Thailand.
+
+    **How it works:**
+    - Step 1: HR Lead gathers all job requirements from you (title, responsibilities, location, salary, etc.)
+    - Step 2: JD Writer creates a bilingual job description (English + Thai + HTML for Indeed)
+    - Step 3: Job Poster publishes the listing to your chosen platform (Indeed Thailand, etc.)
+
+    **What you need:**
+    - Basic information about the role you want to fill
+    - Preferred job board for posting (defaults to Indeed Thailand)
+    - Application contact email
+    """,
+    steps=[
+        # ═══════════════════════════════════════════════════════════════
+        # STEP 1: Gather Requirements
+        # ═══════════════════════════════════════════════════════════════
+        Step(
+            name="Gather Requirements",
+            agent=hr_lead_agent,
+            description="""
+            **STEP 1 of 3: Requirements Gathering**
+
+            Your specific tasks for THIS step only:
+
+            1. **Greet the user** and explain you'll be collecting job details
+               - Be friendly and professional — this should feel like talking to an HR expert
+
+            2. **Collect all required information** (ask 1-2 questions at a time):
+               - Job title (e.g. 'Padel Coach', 'Front Desk Staff')
+               - Department or team
+               - Key responsibilities (3-5 bullet points)
+               - Required qualifications and skills
+               - Location (city/area in Thailand)
+               - Employment type: Full-time / Part-time / Contract
+               - Number of positions available
+
+            3. **Collect optional information** (ask if the user wants to provide):
+               - Salary range (in THB, monthly)
+               - Years of experience required
+               - Nice-to-have skills
+               - Work schedule (weekends, shifts, etc.)
+               - Benefits (social security, health insurance, transport, meals)
+               - Application deadline
+               - Contact email for applications
+
+            4. **Summarize everything** and ask user to confirm
+               - Present a clear summary of all collected details
+               - Ask: "Does this look correct? Any changes before I send this to the JD writer?"
+
+            **IMPORTANT:**
+            - STOP after the user confirms the requirements
+            - Do NOT write the job description yourself (that's Step 2)
+            - End with: "Requirements confirmed. Sending to JD Writer in Step 2."
+            """,
+        ),
+
+        # ═══════════════════════════════════════════════════════════════
+        # STEP 2: Write Job Description
+        # ═══════════════════════════════════════════════════════════════
+        Step(
+            name="Write Job Description",
+            agent=hr_jd_writer_agent,
+            description="""
+            **STEP 2 of 3: Job Description Writing**
+
+            Context from Step 1: The HR Lead has gathered and confirmed all job requirements.
+
+            Your specific tasks for THIS step only:
+
+            1. **Review the requirements** from Step 1
+               - Identify all details: title, responsibilities, qualifications, location, salary, benefits
+
+            2. **Write the complete bilingual job description** with this structure:
+
+               **ENGLISH VERSION**
+               - Job title, company, location, employment type, salary
+               - About the Role (2-3 sentences)
+               - Key Responsibilities (bullet points)
+               - Requirements (bullet points)
+               - Nice to Have
+               - What We Offer (include Social Security / ประกันสังคม)
+               - How to Apply
+
+               **THAI VERSION (เวอร์ชันภาษาไทย)**
+               - Same structure in natural Thai (not word-for-word translation)
+
+               **INDEED HTML VERSION**
+               - Combined HTML using <h2>, <ul>, <li>, <p> tags only
+               - Under 5000 characters
+
+            3. **Present the full JD to the user**
+               - Ask: "Here is the job description. Would you like any changes, or shall I proceed to post it?"
+
+            4. **Handle revisions** if requested
+               - Make edits as requested
+               - Present updated version for approval
+
+            **IMPORTANT:**
+            - STOP after the user approves the JD
+            - Do NOT post the job yourself (that's Step 3)
+            - End with: "Job description approved. Ready to post in Step 3."
+            """,
+        ),
+
+        # ═══════════════════════════════════════════════════════════════
+        # STEP 3: Post the Job
+        # ═══════════════════════════════════════════════════════════════
+        Step(
+            name="Post Job to Platform",
+            agent=hr_job_poster_agent,
+            description="""
+            **STEP 3 of 3: Job Posting**
+
+            Context from Step 2: The JD Writer has created an approved bilingual job description.
+
+            Your specific tasks for THIS step only:
+
+            1. **Ask which platform to post to**
+               - Call `list_job_boards()` to show available configured platforms
+               - Ask user: "Which platform would you like to post to?"
+               - If user wants a non-configured platform and browser tools are available,
+                 offer to use the managed browser
+
+            2. **Confirm posting details**
+               - Show: job title, platform, location, job type, salary, apply email
+               - Ask: "Shall I proceed with posting?"
+
+            3. **Post the job**
+               - For configured platforms: use `post_job_to_board(...)`
+               - For other platforms: use browser tools if available
+               - If browser tools are not available, explain and suggest configured platforms
+
+            4. **Report results**
+               - Share the live job URL if available
+               - Confirm the posting was successful
+
+               Example:
+               ```
+               ═══════════════════════════════════════
+               Job Posted Successfully!
+               ═══════════════════════════════════════
+               Platform: Indeed Thailand
+               Job Title: [title]
+               Location: [location]
+               Status: Live
+               URL: [job URL if available]
+               ═══════════════════════════════════════
+               ```
+
+            **IMPORTANT:**
+            - NEVER post without explicit user confirmation
+            - If credentials are missing, tell the user to set them up
+            - This is the final step — end with clear confirmation
+            """,
+        ),
+    ],
+)


### PR DESCRIPTION
## Summary
- **kimi-k2.5 with thinking disabled** — uses the correct Moonshot API param `{"thinking": {"type": "disabled"}}` via `extra_body`, as documented at [platform.moonshot.ai](https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model). This fixes the crash: _"thinking is enabled but reasoning_content is missing at index 2"_
- **Real Agno Workflow** — created `workflows/hr_workflow.py` using `Workflow + Step` (not just a Team), giving a deterministic 3-step pipeline: gather requirements → write bilingual JD → post to platform
- **Browser tool resilience** — `hr_job_poster` gracefully handles when Browserbase env vars aren't set, and logs clearly which vars are missing

## Files Changed
- `agents/hr_lead.py` — kimi-k2.5 + thinking disabled
- `agents/hr_jd_writer.py` — kimi-k2.5 + thinking disabled
- `agents/hr_job_poster.py` — kimi-k2.5 + thinking disabled + graceful degradation
- `teams/hr_team.py` — kimi-k2.5 + thinking disabled
- `workflows/hr_workflow.py` — NEW: proper Agno Workflow with 3 Steps
- `workflows/__init__.py` — exports hr_workflow
- `agno_agent.py` — registers hr_workflow in AgentOS
- `services/tool_providers.py` — improved browser env var diagnostics

## Test Plan
- [ ] Run HR team — no thinking error, JD writes fast
- [ ] Run HR workflow — all 3 steps execute in sequence
- [ ] Test with Browserbase env vars missing — agent falls back gracefully to job board API

🤖 Generated with [Claude Code](https://claude.com/claude-code)