### PR TITLE
Feature: Use product_team in Slack interface

### DIFF
--- a/agno_agent.py
+++ b/agno_agent.py
@@ -55,7 +55,7 @@ from instagram_agent import instagram_agent  # Instagram Agent (OAuth-enabled)
 agent_os = AgentOS(
     name="Agent OS",
     interfaces=[
-        Slack(agent=software_engineer_agent),
+        Slack(team=product_team),
     ],
     agents=[
         credentials_manager_agent,  # Credentials Manager (validates tokens before workflows)


### PR DESCRIPTION
## Summary
- Switches the Slack interface from `software_engineer_agent` back to `product_team` so users interact with the full product team (with delegation to specialized agents) rather than a single agent

## Test plan
- [ ] Verify Slack messages are handled by product_team and delegated to appropriate agents
- [ ] Verify tool injection and Slack ID resolution still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)